### PR TITLE
Adapting Breez Theme

### DIFF
--- a/lib/ui/anytime_podcast_app.dart
+++ b/lib/ui/anytime_podcast_app.dart
@@ -303,6 +303,7 @@ class _AnytimeHomePageState extends State<AnytimeHomePage> with WidgetsBindingOb
               type: BottomNavigationBarType.fixed,
               backgroundColor: Theme.of(context).bottomAppBarColor,
               selectedIconTheme: Theme.of(context).iconTheme,
+              unselectedItemColor: Theme.of(context).unselectedWidgetColor,
               currentIndex: snapshot.data,
               onTap: pager.changePage,
               items: <BottomNavigationBarItem>[

--- a/lib/ui/anytime_podcast_app.dart
+++ b/lib/ui/anytime_podcast_app.dart
@@ -303,6 +303,7 @@ class _AnytimeHomePageState extends State<AnytimeHomePage> with WidgetsBindingOb
               type: BottomNavigationBarType.fixed,
               backgroundColor: Theme.of(context).bottomAppBarColor,
               selectedIconTheme: Theme.of(context).iconTheme,
+              selectedItemColor: Theme.of(context).iconTheme.color,
               currentIndex: snapshot.data,
               onTap: pager.changePage,
               items: <BottomNavigationBarItem>[

--- a/lib/ui/anytime_podcast_app.dart
+++ b/lib/ui/anytime_podcast_app.dart
@@ -303,7 +303,6 @@ class _AnytimeHomePageState extends State<AnytimeHomePage> with WidgetsBindingOb
               type: BottomNavigationBarType.fixed,
               backgroundColor: Theme.of(context).bottomAppBarColor,
               selectedIconTheme: Theme.of(context).iconTheme,
-              selectedItemColor: Theme.of(context).iconTheme.color,
               currentIndex: snapshot.data,
               onTap: pager.changePage,
               items: <BottomNavigationBarItem>[

--- a/lib/ui/anytime_podcast_app.dart
+++ b/lib/ui/anytime_podcast_app.dart
@@ -303,7 +303,7 @@ class _AnytimeHomePageState extends State<AnytimeHomePage> with WidgetsBindingOb
               type: BottomNavigationBarType.fixed,
               backgroundColor: Theme.of(context).bottomAppBarColor,
               selectedIconTheme: Theme.of(context).iconTheme,
-              selectedItemColor: Theme.of(context).iconTheme.color,
+              unselectedItemColor: Theme.of(context).disabledColor,
               currentIndex: snapshot.data,
               onTap: pager.changePage,
               items: <BottomNavigationBarItem>[

--- a/lib/ui/anytime_podcast_app.dart
+++ b/lib/ui/anytime_podcast_app.dart
@@ -304,7 +304,7 @@ class _AnytimeHomePageState extends State<AnytimeHomePage> with WidgetsBindingOb
               backgroundColor: Theme.of(context).bottomAppBarColor,
               selectedIconTheme: Theme.of(context).iconTheme,
               selectedItemColor: Theme.of(context).iconTheme.color,
-              unselectedItemColor: Theme.of(context).unselectedWidgetColor,
+              unselectedItemColor: Theme.of(context).disabledColor,
               currentIndex: snapshot.data,
               onTap: pager.changePage,
               items: <BottomNavigationBarItem>[

--- a/lib/ui/anytime_podcast_app.dart
+++ b/lib/ui/anytime_podcast_app.dart
@@ -303,7 +303,7 @@ class _AnytimeHomePageState extends State<AnytimeHomePage> with WidgetsBindingOb
               type: BottomNavigationBarType.fixed,
               backgroundColor: Theme.of(context).bottomAppBarColor,
               selectedIconTheme: Theme.of(context).iconTheme,
-              unselectedItemColor: Theme.of(context).disabledColor,
+              selectedItemColor: Theme.of(context).iconTheme.color,
               currentIndex: snapshot.data,
               onTap: pager.changePage,
               items: <BottomNavigationBarItem>[

--- a/lib/ui/anytime_podcast_app.dart
+++ b/lib/ui/anytime_podcast_app.dart
@@ -303,6 +303,7 @@ class _AnytimeHomePageState extends State<AnytimeHomePage> with WidgetsBindingOb
               type: BottomNavigationBarType.fixed,
               backgroundColor: Theme.of(context).bottomAppBarColor,
               selectedIconTheme: Theme.of(context).iconTheme,
+              selectedItemColor: Theme.of(context).iconTheme.color,
               unselectedItemColor: Theme.of(context).unselectedWidgetColor,
               currentIndex: snapshot.data,
               onTap: pager.changePage,

--- a/lib/ui/library/discovery_results.dart
+++ b/lib/ui/library/discovery_results.dart
@@ -48,7 +48,7 @@ class DiscoveryResults extends StatelessWidget {
                   children: <Widget>[
                     Icon(
                       Icons.search,
-                      size: 75,
+                      size: 48,
                       color: Theme.of(context).primaryColor,
                     ),
                     Text(

--- a/lib/ui/library/downloads.dart
+++ b/lib/ui/library/downloads.dart
@@ -101,7 +101,7 @@ class _DownloadsState extends State<Downloads> {
             children: <Widget>[
               Icon(
                 Icons.cloud_download,
-                size: 75,
+                size: 45,
                 color: Theme.of(context).primaryColor,
               ),
               Text(

--- a/lib/ui/library/library.dart
+++ b/lib/ui/library/library.dart
@@ -39,7 +39,7 @@ class _LibraryState extends State<Library> {
                     children: <Widget>[
                       Icon(
                         Icons.headset,
-                        size: 75,
+                        size: 45,
                         color: Theme.of(context).primaryColor,
                       ),
                       Text(

--- a/lib/ui/podcast/now_playing.dart
+++ b/lib/ui/podcast/now_playing.dart
@@ -142,18 +142,15 @@ class NowPlayingHeader extends StatelessWidget {
                   imageUrl: imageUrl,
                   placeholder: (context, url) {
                     return Container(
+                      color: Theme.of(context).primaryColorLight,
                       constraints: BoxConstraints.expand(),
-                      child: Placeholder(
-                        color: Colors.grey,
-                        strokeWidth: 1,
-                      ),
                     );
                   },
                   errorWidget: (_, __, dynamic ___) {
                     return Container(
                       constraints: BoxConstraints.expand(),
                       child: Placeholder(
-                        color: Colors.grey,
+                        color: Theme.of(context).errorColor,
                         strokeWidth: 1,
                       ),
                     );

--- a/lib/ui/podcast/player_transport_controls.dart
+++ b/lib/ui/podcast/player_transport_controls.dart
@@ -116,7 +116,7 @@ class _PlayerTransportControlsState extends State<PlayerTransportControls> with 
                       }
                     },
                     shape: CircleBorder(side: BorderSide(color: Theme.of(context).highlightColor, width: 0.0)),
-                    color: Theme.of(context).brightness == Brightness.light ? Colors.orange : Colors.grey[800],
+                    color: Theme.of(context).brightness == Brightness.light ? Theme.of(context).buttonColor : Colors.grey[800],
                     padding: const EdgeInsets.all(8.0),
                     child: AnimatedIcon(
                       size: 60.0,

--- a/lib/ui/podcast/podcast_details.dart
+++ b/lib/ui/podcast/podcast_details.dart
@@ -170,20 +170,15 @@ class _PodcastDetailsState extends State<PodcastDetails> {
                       fit: BoxFit.fitWidth,
                       placeholder: (context, url) {
                         return Container(
+                          color: Theme.of(context).primaryColorLight,
                           constraints: BoxConstraints.expand(height: 60, width: 60),
-                          child: Placeholder(
-                            color: Colors.grey,
-                            strokeWidth: 1,
-                            fallbackWidth: 60,
-                            fallbackHeight: 60,
-                          ),
                         );
                       },
                       errorWidget: (_, __, dynamic ___) {
                         return Container(
                           constraints: BoxConstraints.expand(height: 60, width: 60),
                           child: Placeholder(
-                            color: Colors.grey,
+                            color: Theme.of(context).errorColor,
                             strokeWidth: 1,
                             fallbackWidth: 60,
                             fallbackHeight: 60,

--- a/lib/ui/search/search_results.dart
+++ b/lib/ui/search/search_results.dart
@@ -46,7 +46,7 @@ class SearchResults extends StatelessWidget {
                   children: <Widget>[
                     Icon(
                       Icons.search,
-                      size: 75,
+                      size: 45,
                       color: Theme.of(context).primaryColor,
                     ),
                     Text(

--- a/lib/ui/themes.dart
+++ b/lib/ui/themes.dart
@@ -41,6 +41,7 @@ ThemeData _buildLightTheme() {
     errorColor: Color(0xffd32f2f),
     primaryTextTheme: Typography.material2018(platform: TargetPlatform.android).black,
     textTheme: Typography.material2018(platform: TargetPlatform.android).black,
+    accentTextTheme: Typography.material2018(platform: TargetPlatform.android).black,
     primaryIconTheme: IconThemeData(color: Colors.grey[800]),
     iconTheme: IconThemeData(color: Colors.orange),
     appBarTheme: base.appBarTheme.copyWith(
@@ -83,6 +84,7 @@ ThemeData _buildDarktheme() {
     errorColor: Color(0xffd32f2f),
     primaryTextTheme: Typography.material2018(platform: TargetPlatform.android).white,
     textTheme: Typography.material2018(platform: TargetPlatform.android).white,
+    accentTextTheme: Typography.material2018(platform: TargetPlatform.android).white,
     primaryIconTheme: IconThemeData(color: Colors.white),
     iconTheme: IconThemeData(color: Colors.white),
     dividerTheme: base.dividerTheme.copyWith(

--- a/lib/ui/themes.dart
+++ b/lib/ui/themes.dart
@@ -69,7 +69,7 @@ ThemeData _buildDarktheme() {
     highlightColor: Color(0xff222222),
     splashColor: Color(0x66c8c8c8),
     selectedRowColor: Color(0xfff5f5f5),
-    unselectedWidgetColor: Color(0x8a000000),
+    unselectedWidgetColor: Colors.grey,
     disabledColor: Color(0x77ffffff),
     buttonColor: Color(0xffe0e0e0),
     toggleableActiveColor: Color(0xfffb8c00),

--- a/lib/ui/widgets/episode_tile.dart
+++ b/lib/ui/widgets/episode_tile.dart
@@ -157,20 +157,15 @@ class EpisodeTile extends StatelessWidget {
               width: 56,
               placeholder: (context, url) {
                 return Container(
+                  color: Theme.of(context).primaryColorLight,
                   constraints: BoxConstraints.expand(height: 56, width: 56),
-                  child: Placeholder(
-                    color: Colors.grey,
-                    strokeWidth: 1,
-                    fallbackWidth: 56,
-                    fallbackHeight: 56,
-                  ),
                 );
               },
               errorWidget: (_, __, dynamic ___) {
                 return Container(
                   constraints: BoxConstraints.expand(height: 56, width: 56),
                   child: Placeholder(
-                    color: Colors.grey,
+                    color: Theme.of(context).errorColor,
                     strokeWidth: 1,
                     fallbackWidth: 56,
                     fallbackHeight: 56,

--- a/lib/ui/widgets/mini_player_widget.dart
+++ b/lib/ui/widgets/mini_player_widget.dart
@@ -93,8 +93,8 @@ class _MiniPlayerBuilderState extends State<_MiniPlayerBuilder> with SingleTicke
           decoration: BoxDecoration(
               color: Theme.of(context).bottomAppBarColor,
               border: Border(
-                top: Divider.createBorderSide(context, width: 1.0),
-                bottom: Divider.createBorderSide(context, width: 1.0),
+                top: Divider.createBorderSide(context, width: 1.0, color: Theme.of(context).dividerColor),
+                bottom: Divider.createBorderSide(context, width: 1.0, color: Theme.of(context).dividerColor),
               )),
           child: StreamBuilder<Episode>(
               stream: audioBloc.nowPlaying,

--- a/lib/ui/widgets/mini_player_widget.dart
+++ b/lib/ui/widgets/mini_player_widget.dart
@@ -62,7 +62,7 @@ class _MiniPlayerBuilderState extends State<_MiniPlayerBuilder> with SingleTicke
 
   @override
   Widget build(BuildContext context) {
-    final textTheme = Theme.of(context).textTheme;
+    final textTheme = Theme.of(context).accentTextTheme;
     final audioBloc = Provider.of<AudioBloc>(context, listen: false);
 
     return Dismissible(

--- a/lib/ui/widgets/mini_player_widget.dart
+++ b/lib/ui/widgets/mini_player_widget.dart
@@ -170,7 +170,7 @@ class _MiniPlayerBuilderState extends State<_MiniPlayerBuilder> with SingleTicke
                               child: AnimatedIcon(
                                 size: 48.0,
                                 icon: AnimatedIcons.play_pause,
-                                color: Theme.of(context).accentColor,
+                                color: Theme.of(context).iconTheme.color,
                                 progress: _playPauseController,
                               ),
                             );

--- a/lib/ui/widgets/mini_player_widget.dart
+++ b/lib/ui/widgets/mini_player_widget.dart
@@ -111,16 +111,16 @@ class _MiniPlayerBuilderState extends State<_MiniPlayerBuilder> with SingleTicke
                             ? CachedNetworkImage(
                                 imageUrl: snapshot.data.imageUrl,
                                 placeholder: (context, url) {
-                                  return Placeholder(
-                                    color: Colors.grey,
-                                    strokeWidth: 1,
+                                  return Container(
+                                    color: Theme.of(context).primaryColorLight,
+                                    constraints: BoxConstraints.expand(height: 48, width: 48),
                                   );
                                 },
                                 errorWidget: (_, __, dynamic ___) {
                                   return Container(
                                     constraints: BoxConstraints.expand(height: 48, width: 48),
                                     child: Placeholder(
-                                      color: Colors.grey,
+                                      color: Theme.of(context).errorColor,
                                       strokeWidth: 1,
                                       fallbackWidth: 40,
                                       fallbackHeight: 40,

--- a/lib/ui/widgets/mini_player_widget.dart
+++ b/lib/ui/widgets/mini_player_widget.dart
@@ -170,7 +170,7 @@ class _MiniPlayerBuilderState extends State<_MiniPlayerBuilder> with SingleTicke
                               child: AnimatedIcon(
                                 size: 48.0,
                                 icon: AnimatedIcons.play_pause,
-                                color: Theme.of(context).accentColor,
+                                color: Theme.of(context).buttonColor,
                                 progress: _playPauseController,
                               ),
                             );

--- a/lib/ui/widgets/mini_player_widget.dart
+++ b/lib/ui/widgets/mini_player_widget.dart
@@ -170,7 +170,7 @@ class _MiniPlayerBuilderState extends State<_MiniPlayerBuilder> with SingleTicke
                               child: AnimatedIcon(
                                 size: 48.0,
                                 icon: AnimatedIcons.play_pause,
-                                color: Theme.of(context).buttonColor,
+                                color: Theme.of(context).accentColor,
                                 progress: _playPauseController,
                               ),
                             );

--- a/lib/ui/widgets/play_pause_button_widget.dart
+++ b/lib/ui/widgets/play_pause_button_widget.dart
@@ -67,7 +67,7 @@ class PlayPauseBusyButton extends StatelessWidget {
                 center: Icon(
                   icon,
                   size: 28.0,
-                  color: Colors.orange,
+                  color: Theme.of(context).buttonColor,
                 ),
               ),
               const SpinKitRing(

--- a/lib/ui/widgets/podcast_list.dart
+++ b/lib/ui/widgets/podcast_list.dart
@@ -45,7 +45,7 @@ class PodcastList extends StatelessWidget {
             children: <Widget>[
               Icon(
                 Icons.search,
-                size: 75,
+                size: 45,
                 color: Theme.of(context).primaryColor,
               ),
               Text(

--- a/lib/ui/widgets/podcast_tile.dart
+++ b/lib/ui/widgets/podcast_tile.dart
@@ -51,20 +51,15 @@ class PodcastTile extends StatelessWidget {
                 width: 60,
                 placeholder: (context, url) {
                   return Container(
+                    color: _theme.primaryColorLight,
                     constraints: BoxConstraints.expand(height: 60, width: 60),
-                    child: Placeholder(
-                      color: Colors.grey,
-                      strokeWidth: 1,
-                      fallbackWidth: 60,
-                      fallbackHeight: 60,
-                    ),
                   );
                 },
                 errorWidget: (_, __, dynamic ___) {
                   return Container(
                     constraints: BoxConstraints.expand(height: 60, width: 60),
                     child: Placeholder(
-                      color: Colors.grey,
+                      color: _theme.errorColor,
                       strokeWidth: 1,
                       fallbackWidth: 60,
                       fallbackHeight: 60,

--- a/lib/ui/widgets/transport_controls.dart
+++ b/lib/ui/widgets/transport_controls.dart
@@ -242,7 +242,7 @@ class DownloadControl extends StatelessWidget {
           BasicDialogAction(
             title: Text(
               L.of(context).cancel_button_label,
-              style: TextStyle(color: Colors.orange),
+              style: TextStyle(color: Theme.of(context).buttonColor),
             ),
             onPressed: () {
               Navigator.pop(context);
@@ -251,7 +251,7 @@ class DownloadControl extends StatelessWidget {
           BasicDialogAction(
             title: Text(
               L.of(context).stop_download_button_label,
-              style: TextStyle(color: Colors.orange),
+              style: TextStyle(color: Theme.of(context).buttonColor),
             ),
             onPressed: () {
               _episodeBloc.deleteDownload(episode);


### PR DESCRIPTION
This PR addresses [BU-273](https://breeztech.atlassian.net/browse/BU-273).

- Reduced icon size of information messages
- Replaced static colors with their theme counterpart
- Added unselectedItemColor to BottomNavigationBar that uses unselectedWidgetColor
- Mini Player widget now uses accentTextTheme and it's divider uses dividerColor from theme