### PR TITLE
Apply overridden theme changes to status bar

### DIFF
--- a/lib/ui/anytime_podcast_app.dart
+++ b/lib/ui/anytime_podcast_app.dart
@@ -243,6 +243,14 @@ class _AnytimeHomePageState extends State<AnytimeHomePage> with WidgetsBindingOb
                   visible: widget.topBarVisible,
                   sliver: SliverAppBar(
                     title: TitleWidget(),
+                    backwardsCompatibility: false,
+                    systemOverlayStyle: SystemUiOverlayStyle(
+                      statusBarIconBrightness:
+                      Theme.of(context).brightness == Brightness.light
+                          ? Brightness.dark
+                          : Brightness.light,
+                      statusBarColor: Theme.of(context).scaffoldBackgroundColor,
+                    ),
                     brightness: brightness,
                     backgroundColor: backgroundColour,
                     floating: false,

--- a/lib/ui/podcast/podcast_details.dart
+++ b/lib/ui/podcast/podcast_details.dart
@@ -17,6 +17,7 @@ import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_dialogs/flutter_dialogs.dart';
 import 'package:liquid_pull_to_refresh/liquid_pull_to_refresh.dart';
@@ -132,6 +133,14 @@ class _PodcastDetailsState extends State<PodcastDetails> {
             controller: _sliverScrollController,
             slivers: <Widget>[
               SliverAppBar(
+                backwardsCompatibility: false,
+                systemOverlayStyle: SystemUiOverlayStyle(
+                  statusBarIconBrightness:
+                  Theme.of(context).brightness == Brightness.light
+                      ? Brightness.dark
+                      : Brightness.light,
+                  statusBarColor: Theme.of(context).scaffoldBackgroundColor,
+                ),
                 brightness: brightness,
                 title: AnimatedOpacity(
                   opacity: toolbarCollpased ? 1.0 : 0.0,

--- a/lib/ui/search/search.dart
+++ b/lib/ui/search/search.dart
@@ -7,6 +7,7 @@ import 'package:anytime/bloc/search/search_state_event.dart';
 import 'package:anytime/l10n/L.dart';
 import 'package:anytime/ui/search/search_results.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:provider/provider.dart';
 
 class Search extends StatefulWidget {
@@ -46,6 +47,14 @@ class _SearchState extends State<Search> {
       body: CustomScrollView(
         slivers: <Widget>[
           SliverAppBar(
+            backwardsCompatibility: false,
+            systemOverlayStyle: SystemUiOverlayStyle(
+              statusBarIconBrightness:
+              Theme.of(context).brightness == Brightness.light
+                  ? Brightness.dark
+                  : Brightness.light,
+              statusBarColor: Theme.of(context).scaffoldBackgroundColor,
+            ),
             brightness: Theme.of(context).brightness,
             leading: IconButton(
               tooltip: L.of(context).search_back_button_label,


### PR DESCRIPTION
Switching between themes reverted status bar color back to plugins color scheme, this change is to make sure the status bar color uses the overridden theme. This has no adverse affect on the plugin itself.