### PR TITLE
Open dialogs without using root navigator

### DIFF
--- a/lib/ui/podcast/podcast_details.dart
+++ b/lib/ui/podcast/podcast_details.dart
@@ -346,8 +346,9 @@ class SubscriptionButton extends StatelessWidget {
                       label: Text(L.of(context).unsubscribe_label),
                       shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8.0)),
                       onPressed: () {
-                        showPlatformDialog<void>(
+                        showDialog<void>(
                           context: context,
+                          useRootNavigator: false,
                           builder: (_) => BasicDialogAlert(
                             title: Text(L.of(context).unsubscribe_label),
                             content: Text(L.of(context).unsubscribe_message),

--- a/lib/ui/settings/settings.dart
+++ b/lib/ui/settings/settings.dart
@@ -103,8 +103,9 @@ class _SettingsState extends State<Settings> {
   }
 
   void _showStorageDialog({@required bool enableExternalStorage}) {
-    showPlatformDialog<void>(
+    showDialog<void>(
       context: context,
+      useRootNavigator: false,
       builder: (_) => BasicDialogAlert(
         title: Text(L.of(context).settings_download_switch_label),
         content: Text(

--- a/lib/ui/widgets/episode_tile.dart
+++ b/lib/ui/widgets/episode_tile.dart
@@ -62,8 +62,9 @@ class EpisodeTile extends StatelessWidget {
               shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(4.0)),
               onPressed: episode.downloaded
                   ? () {
-                      showPlatformDialog<void>(
+                      showDialog<void>(
                         context: context,
+                        useRootNavigator: false,
                         builder: (_) => BasicDialogAlert(
                           title: Text(
                             L.of(context).delete_episode_title,

--- a/lib/ui/widgets/transport_controls.dart
+++ b/lib/ui/widgets/transport_controls.dart
@@ -231,8 +231,9 @@ class DownloadControl extends StatelessWidget {
   Future<void> _showCancelDialog(BuildContext context) {
     final _episodeBloc = Provider.of<EpisodeBloc>(context, listen: false);
 
-    return showPlatformDialog<void>(
+    return showDialog<void>(
       context: context,
+      useRootNavigator: false,
       builder: (_) => BasicDialogAlert(
         title: Text(
           L.of(context).stop_download_title,


### PR DESCRIPTION
When the dialogs are created with using root navigator, Navigator calls through that dialog use root navigator as well. This causes issues when the plugin is opened through an app with it's own instance of Navigator.

_e. g._ Calling Navigator.pop() of a dialog that belongs to plugin through the app would pop an item of apps navigator stack instead of popping the plugins dialog. 

This change does not affect the plugin.