### PR TITLE
Theme changes

### DIFF
--- a/lib/ui/anytime_podcast_app.dart
+++ b/lib/ui/anytime_podcast_app.dart
@@ -352,7 +352,7 @@ class _AnytimeHomePageState extends State<AnytimeHomePage> with WidgetsBindingOb
               GestureDetector(
                   child: Text(
                     'anytime@amugofjava.me.uk',
-                    style: TextStyle(decoration: TextDecoration.underline, color: Colors.orange),
+                    style: TextStyle(decoration: TextDecoration.underline, color: Theme.of.(context).buttonColor),
                   ),
                   onTap: () {
                     _launchEmail();

--- a/lib/ui/anytime_podcast_app.dart
+++ b/lib/ui/anytime_podcast_app.dart
@@ -303,6 +303,8 @@ class _AnytimeHomePageState extends State<AnytimeHomePage> with WidgetsBindingOb
               type: BottomNavigationBarType.fixed,
               backgroundColor: Theme.of(context).bottomAppBarColor,
               selectedIconTheme: Theme.of(context).iconTheme,
+              selectedItemColor: Theme.of(context).iconTheme.color,
+              unselectedItemColor: Theme.of(context).disabledColor,
               currentIndex: snapshot.data,
               onTap: pager.changePage,
               items: <BottomNavigationBarItem>[

--- a/lib/ui/podcast/player_transport_controls.dart
+++ b/lib/ui/podcast/player_transport_controls.dart
@@ -116,7 +116,7 @@ class _PlayerTransportControlsState extends State<PlayerTransportControls> with 
                       }
                     },
                     shape: CircleBorder(side: BorderSide(color: Theme.of(context).highlightColor, width: 0.0)),
-                    color: Theme.of(context).brightness == Brightness.light ? Colors.orange : Colors.grey[800],
+                    color: Theme.of(context).brightness == Brightness.light ? Theme.of.(context).buttonColor : Colors.grey[800],
                     padding: const EdgeInsets.all(8.0),
                     child: AnimatedIcon(
                       size: 60.0,

--- a/lib/ui/themes.dart
+++ b/lib/ui/themes.dart
@@ -41,6 +41,7 @@ ThemeData _buildLightTheme() {
     errorColor: Color(0xffd32f2f),
     primaryTextTheme: Typography.material2018(platform: TargetPlatform.android).black,
     textTheme: Typography.material2018(platform: TargetPlatform.android).black,
+    accentTextTheme: Typography.material2018(platform: TargetPlatform.android).black,
     primaryIconTheme: IconThemeData(color: Colors.grey[800]),
     iconTheme: IconThemeData(color: Colors.orange),
     appBarTheme: base.appBarTheme.copyWith(
@@ -83,6 +84,7 @@ ThemeData _buildDarktheme() {
     errorColor: Color(0xffd32f2f),
     primaryTextTheme: Typography.material2018(platform: TargetPlatform.android).white,
     textTheme: Typography.material2018(platform: TargetPlatform.android).white,
+    accentTextTheme: Typography.material2018(platform: TargetPlatform.android).white,
     primaryIconTheme: IconThemeData(color: Colors.white),
     iconTheme: IconThemeData(color: Colors.white),
     dividerTheme: base.dividerTheme.copyWith(

--- a/lib/ui/widgets/mini_player_widget.dart
+++ b/lib/ui/widgets/mini_player_widget.dart
@@ -93,8 +93,8 @@ class _MiniPlayerBuilderState extends State<_MiniPlayerBuilder> with SingleTicke
           decoration: BoxDecoration(
               color: Theme.of(context).bottomAppBarColor,
               border: Border(
-                top: Divider.createBorderSide(context, width: 1.0),
-                bottom: Divider.createBorderSide(context, width: 1.0),
+                top: Divider.createBorderSide(context, width: 1.0, color: Theme.of(context).dividerColor),
+                bottom: Divider.createBorderSide(context, width: 1.0, color: Theme.of(context).dividerColor),
               )),
           child: StreamBuilder<Episode>(
               stream: audioBloc.nowPlaying,

--- a/lib/ui/widgets/mini_player_widget.dart
+++ b/lib/ui/widgets/mini_player_widget.dart
@@ -62,7 +62,7 @@ class _MiniPlayerBuilderState extends State<_MiniPlayerBuilder> with SingleTicke
 
   @override
   Widget build(BuildContext context) {
-    final textTheme = Theme.of(context).textTheme;
+    final textTheme = Theme.of(context).accentTextTheme;
     final audioBloc = Provider.of<AudioBloc>(context, listen: false);
 
     return Dismissible(

--- a/lib/ui/widgets/mini_player_widget.dart
+++ b/lib/ui/widgets/mini_player_widget.dart
@@ -170,7 +170,7 @@ class _MiniPlayerBuilderState extends State<_MiniPlayerBuilder> with SingleTicke
                               child: AnimatedIcon(
                                 size: 48.0,
                                 icon: AnimatedIcons.play_pause,
-                                color: Theme.of(context).accentColor,
+                                color: Theme.of(context).iconTheme.color,
                                 progress: _playPauseController,
                               ),
                             );

--- a/lib/ui/widgets/play_pause_button_widget.dart
+++ b/lib/ui/widgets/play_pause_button_widget.dart
@@ -67,7 +67,7 @@ class PlayPauseBusyButton extends StatelessWidget {
                 center: Icon(
                   icon,
                   size: 28.0,
-                  color: Colors.orange,
+                  color: Theme.of.(context).buttonColor,
                 ),
               ),
               const SpinKitRing(

--- a/lib/ui/widgets/transport_controls.dart
+++ b/lib/ui/widgets/transport_controls.dart
@@ -224,7 +224,7 @@ class DownloadControl extends StatelessWidget {
           BasicDialogAction(
             title: Text(
               L.of(context).cancel_button_label,
-              style: TextStyle(color: Colors.orange),
+              style: TextStyle(color: Theme.of.(context).buttonColor),
             ),
             onPressed: () {
               Navigator.pop(context);
@@ -233,7 +233,7 @@ class DownloadControl extends StatelessWidget {
           BasicDialogAction(
             title: Text(
               L.of(context).stop_download_button_label,
-              style: TextStyle(color: Colors.orange),
+              style: TextStyle(color: Theme.of.(context).buttonColor),
             ),
             onPressed: () {
               _episodeBloc.deleteDownload(episode);


### PR DESCRIPTION
This PR is adding the minimum necessary changes to apply theme customizations made in [#421](https://github.com/breez/breezmobile/pull/421), they have no visual effect on the plugin itself.

- Replaced static colors with their theme counterparts, Colors.orange -> Theme.buttonColor
- Added selectedItemColor and unselectedItemColor parameters to BottomNavigationBar,
- Mini Player widgets
  - textTheme has changed to accentTextTheme,
  - divider now uses dividerColor from theme,
  - play button uses iconTheme.color instead of accentColor.