### PR TITLE
Change layout of minimize button and use iconColor from theme

### DIFF
--- a/lib/ui/podcast/now_playing.dart
+++ b/lib/ui/podcast/now_playing.dart
@@ -79,32 +79,38 @@ class _NowPlayingState extends State<NowPlaying> with WidgetsBindingObserver {
                       elevation: 0.0,
                       leading: IconButton(
                         tooltip: L.of(context).minimise_player_window_button_label,
-                        icon: Icon(Icons.keyboard_arrow_down),
+                        icon: Icon(Icons.keyboard_arrow_down, color: Theme.of(context).primaryColor),
                         onPressed: () => {
                           Navigator.pop(context),
                         },
                       ),
                     ),
                   ),
-                  Column(
-                    crossAxisAlignment: CrossAxisAlignment.center,
-                    mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-                    children: <Widget>[
-                      snapshot.data == null
-                          ? Container()
-                          : Expanded(
-                              child: NowPlayingHeader(imageUrl: snapshot.data.imageUrl),
-                              flex: 6,
-                            ),
-                      Expanded(
-                        child: NowPlayingDetails(title: snapshot.data.title, description: snapshot.data.description),
-                        flex: 4,
-                      ),
-                      SizedBox(
-                        height: 160.0,
-                        child: NowPlayingTransport(duration: duration),
-                      ),
-                    ],
+                  Padding(
+                    padding: const EdgeInsets.only(top: 40.0),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.center,
+                      mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                      children: <Widget>[
+                        snapshot.data == null
+                            ? Container()
+                            : Expanded(
+                                child: NowPlayingHeader(
+                                    imageUrl: snapshot.data.imageUrl),
+                                flex: 9,
+                              ),
+                        Expanded(
+                          child: NowPlayingDetails(
+                              title: snapshot.data.title,
+                              description: snapshot.data.description),
+                          flex: 4,
+                        ),
+                        SizedBox(
+                          height: 160.0,
+                          child: NowPlayingTransport(duration: duration),
+                        ),
+                      ],
+                    ),
                   )
                 ],
               ),


### PR DESCRIPTION
This PR addresses [BU-280](https://breeztech.atlassian.net/browse/BU-280)

Theme values are applied to minimize button and it's layout is changed so that it's no longer under podcast image.