### PR TITLE
Status bar changes

### DIFF
--- a/lib/ui/anytime_podcast_app.dart
+++ b/lib/ui/anytime_podcast_app.dart
@@ -10,7 +10,6 @@ import 'package:anytime/bloc/podcast/podcast_bloc.dart';
 import 'package:anytime/bloc/search/search_bloc.dart';
 import 'package:anytime/bloc/settings/settings_bloc.dart';
 import 'package:anytime/bloc/ui/pager_bloc.dart';
-import 'package:anytime/core/chrome.dart';
 import 'package:anytime/l10n/L.dart';
 import 'package:anytime/repository/repository.dart';
 import 'package:anytime/repository/sembast/sembast_repository.dart';
@@ -84,23 +83,13 @@ class _AnytimePodcastAppState extends State<AnytimePodcastApp> {
         /// Only update the theme if it has changed.
         if (newTheme != theme) {
           theme = newTheme;
-
-          if (event.theme == 'dark') {
-            Chrome.transparentDark();
-          } else {
-            Chrome.transparentLight();
-          }
         }
       });
     });
 
     if (widget.mobileSettingsService.themeDarkMode) {
       theme = Themes.darkTheme().themeData;
-
-      Chrome.transparentDark();
     } else {
-      Chrome.transparentLight();
-
       theme = Themes.lightTheme().themeData;
     }
   }
@@ -243,6 +232,12 @@ class _AnytimeHomePageState extends State<AnytimeHomePage> with WidgetsBindingOb
                   visible: widget.topBarVisible,
                   sliver: SliverAppBar(
                     title: TitleWidget(),
+                    backwardsCompatibility: false,
+                    systemOverlayStyle: SystemUiOverlayStyle(
+                      statusBarIconBrightness:
+                          Theme.of(context).brightness == Brightness.light ? Brightness.dark : Brightness.light,
+                      statusBarColor: Colors.transparent,
+                    ),
                     brightness: brightness,
                     backgroundColor: backgroundColour,
                     floating: false,

--- a/lib/ui/podcast/podcast_details.dart
+++ b/lib/ui/podcast/podcast_details.dart
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 import 'package:anytime/bloc/podcast/podcast_bloc.dart';
-import 'package:anytime/core/chrome.dart';
 import 'package:anytime/entities/episode.dart';
 import 'package:anytime/entities/feed.dart';
 import 'package:anytime/entities/podcast.dart';
@@ -17,6 +16,7 @@ import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_dialogs/flutter_dialogs.dart';
 import 'package:liquid_pull_to_refresh/liquid_pull_to_refresh.dart';
@@ -29,9 +29,8 @@ import 'package:provider/provider.dart';
 class PodcastDetails extends StatefulWidget {
   final Podcast podcast;
   final PodcastBloc _podcastBloc;
-  final bool _darkMode;
 
-  PodcastDetails(this.podcast, this._podcastBloc, this._darkMode);
+  PodcastDetails(this.podcast, this._podcastBloc);
 
   @override
   _PodcastDetailsState createState() => _PodcastDetailsState();
@@ -41,7 +40,7 @@ class _PodcastDetailsState extends State<PodcastDetails> {
   final log = Logger('PodcastDetails');
   final ScrollController _sliverScrollController = ScrollController();
   var brightness = Brightness.dark;
-
+  SystemUiOverlayStyle _systemOverlayStyle;
   bool toolbarCollpased = false;
 
   @override
@@ -51,7 +50,6 @@ class _PodcastDetailsState extends State<PodcastDetails> {
     // Load the details of the Podcast specified in the URL
     log.fine('initState() - load feed');
     widget._podcastBloc.load(Feed(podcast: widget.podcast));
-    brightness = widget._darkMode ? Brightness.dark : Brightness.light;
 
     // We only want to display the podcast title when the toolbar is in a
     // collapsed state. Add a listener and set toollbarCollapsed variable
@@ -59,32 +57,25 @@ class _PodcastDetailsState extends State<PodcastDetails> {
     _sliverScrollController.addListener(() {
       if (!toolbarCollpased && _sliverScrollController.hasClients && _sliverScrollController.offset > (300 - kToolbarHeight)) {
         setState(() {
-          if (widget._darkMode) {
-            Chrome.transparentDark();
-            brightness = Brightness.light;
-          } else {
-            Chrome.transparentLight();
-            brightness = Brightness.light;
-          }
-
           toolbarCollpased = true;
         });
       } else if (toolbarCollpased &&
           _sliverScrollController.hasClients &&
           _sliverScrollController.offset < (300 - kToolbarHeight)) {
         setState(() {
-          if (widget._darkMode) {
-            Chrome.translucentDark();
-            brightness = Brightness.light;
-          } else {
-            Chrome.translucentLight();
-            brightness = Brightness.dark;
-          }
-
           toolbarCollpased = false;
         });
       }
     });
+  }
+
+  @override
+  void didChangeDependencies() {
+    _systemOverlayStyle = SystemUiOverlayStyle(
+      statusBarIconBrightness: Theme.of(context).brightness == Brightness.light ? Brightness.dark : Brightness.light,
+      statusBarColor: Theme.of(context).appBarTheme.backgroundColor.withOpacity(toolbarCollpased ? 1.0 : 0.5),
+    );
+    super.didChangeDependencies();
   }
 
   @override
@@ -101,30 +92,26 @@ class _PodcastDetailsState extends State<PodcastDetails> {
     ));
   }
 
-  void _setChrome({bool darkMode}) {
-    if (darkMode) {
-      Chrome.transparentDark();
-    } else {
-      Chrome.transparentLight();
-    }
+  _resetSystemOverlayStyle() {
+    setState(() {
+      _systemOverlayStyle = SystemUiOverlayStyle(
+        statusBarIconBrightness: Theme.of(context).brightness == Brightness.light ? Brightness.dark : Brightness.light,
+        statusBarColor: Colors.transparent,
+      );
+    });
   }
 
   @override
   Widget build(BuildContext context) {
-    final backgroundColour = Theme.of(context).backgroundColor;
-    final defaultBrightness = Theme.of(context).brightness;
     final _podcastBloc = Provider.of<PodcastBloc>(context);
-
-    brightness = toolbarCollpased ? defaultBrightness : Brightness.dark;
 
     return WillPopScope(
       onWillPop: () {
-        _setChrome(darkMode: widget._darkMode);
-
+        _resetSystemOverlayStyle();
         return Future.value(true);
       },
       child: Scaffold(
-        backgroundColor: backgroundColour,
+        backgroundColor: Theme.of(context).backgroundColor,
         body: LiquidPullToRefresh(
           onRefresh: _handleRefresh,
           showChildOpacityTransition: false,
@@ -132,7 +119,9 @@ class _PodcastDetailsState extends State<PodcastDetails> {
             controller: _sliverScrollController,
             slivers: <Widget>[
               SliverAppBar(
-                brightness: brightness,
+                backwardsCompatibility: false,
+                systemOverlayStyle: _systemOverlayStyle,
+                brightness: toolbarCollpased ? Theme.of(context).brightness : Brightness.dark,
                 title: AnimatedOpacity(
                   opacity: toolbarCollpased ? 1.0 : 0.0,
                   duration: Duration(milliseconds: 500),
@@ -140,23 +129,13 @@ class _PodcastDetailsState extends State<PodcastDetails> {
                 ),
                 leading: DecoratedIconButton(
                   icon: Icons.close,
-                  iconColour: toolbarCollpased && defaultBrightness == Brightness.light ? Colors.black : Colors.white,
+                  iconColour: toolbarCollpased && Theme.of(context).brightness == Brightness.light ? Colors.black : Colors.white,
                   decorationColour: toolbarCollpased ? Color(0x00000000) : Color(0x22000000),
                   onPressed: () {
-                    setState(() {
-                      // We need to switch brightness to light here. If we do not,
-                      // it will stay dark until the previous screen is rebuilt and
-                      // that results in the status bar being blank for a few
-                      // milliseconds which looks very odd.
-                      brightness = widget._darkMode ? Brightness.dark : Brightness.light;
-                    });
-
-                    _setChrome(darkMode: widget._darkMode);
-
+                    _resetSystemOverlayStyle();
                     Navigator.pop(context);
                   },
                 ),
-                backgroundColor: Theme.of(context).appBarTheme.color,
                 expandedHeight: 300.0,
                 floating: false,
                 pinned: true,

--- a/lib/ui/search/search.dart
+++ b/lib/ui/search/search.dart
@@ -7,6 +7,7 @@ import 'package:anytime/bloc/search/search_state_event.dart';
 import 'package:anytime/l10n/L.dart';
 import 'package:anytime/ui/search/search_results.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:provider/provider.dart';
 
 class Search extends StatefulWidget {
@@ -46,6 +47,11 @@ class _SearchState extends State<Search> {
       body: CustomScrollView(
         slivers: <Widget>[
           SliverAppBar(
+            backwardsCompatibility: false,
+            systemOverlayStyle: SystemUiOverlayStyle(
+              statusBarIconBrightness: Theme.of(context).brightness == Brightness.light ? Brightness.dark : Brightness.light,
+              statusBarColor: Colors.transparent,
+            ),
             brightness: Theme.of(context).brightness,
             leading: IconButton(
               tooltip: L.of(context).search_back_button_label,

--- a/lib/ui/settings/settings.dart
+++ b/lib/ui/settings/settings.dart
@@ -9,6 +9,7 @@ import 'package:anytime/l10n/L.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_dialogs/flutter_dialogs.dart';
 import 'package:provider/provider.dart';
 
@@ -85,6 +86,11 @@ class _SettingsState extends State<Settings> {
   Widget _buildAndroid(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
+        backwardsCompatibility: false,
+        systemOverlayStyle: SystemUiOverlayStyle(
+          statusBarIconBrightness: Theme.of(context).brightness == Brightness.light ? Brightness.dark : Brightness.light,
+          statusBarColor: Colors.transparent,
+        ),
         brightness: Theme.of(context).brightness,
         elevation: 0.0,
         title: Text(

--- a/lib/ui/themes.dart
+++ b/lib/ui/themes.dart
@@ -44,6 +44,8 @@ ThemeData _buildLightTheme() {
     primaryIconTheme: IconThemeData(color: Colors.grey[800]),
     iconTheme: IconThemeData(color: Colors.orange),
     appBarTheme: base.appBarTheme.copyWith(
+      backgroundColor: Colors.white,
+      foregroundColor: Colors.black,
       color: Colors.white,
     ),
   );
@@ -89,7 +91,7 @@ ThemeData _buildDarktheme() {
       color: Color(0xff444444),
     ),
     appBarTheme: base.appBarTheme.copyWith(
-      color: Color(0xff222222),
+      backgroundColor: Color(0xff222222),
       shadowColor: Color(0xff222222),
       elevation: 1.0,
     ),

--- a/lib/ui/widgets/podcast_tile.dart
+++ b/lib/ui/widgets/podcast_tile.dart
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 import 'package:anytime/bloc/podcast/podcast_bloc.dart';
-import 'package:anytime/core/chrome.dart';
 import 'package:anytime/entities/podcast.dart';
 import 'package:anytime/ui/podcast/podcast_details.dart';
 import 'package:cached_network_image/cached_network_image.dart';
@@ -21,8 +20,6 @@ class PodcastTile extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final _podcastBloc = Provider.of<PodcastBloc>(context);
-    final _theme = Theme.of(context);
-    final darkMode = _theme.brightness == Brightness.dark;
 
     return Center(
       child: Column(
@@ -31,15 +28,9 @@ class PodcastTile extends StatelessWidget {
         children: <Widget>[
           ListTile(
             onTap: () {
-              if (darkMode) {
-                Chrome.translucentDark();
-              } else {
-                Chrome.translucentLight();
-              }
-
               Navigator.push(
                 context,
-                MaterialPageRoute<void>(builder: (context) => PodcastDetails(podcast, _podcastBloc, darkMode)),
+                MaterialPageRoute<void>(builder: (context) => PodcastDetails(podcast, _podcastBloc)),
               );
             },
             leading: Hero(

--- a/lib/ui/widgets/show_notes.dart
+++ b/lib/ui/widgets/show_notes.dart
@@ -5,6 +5,7 @@
 import 'package:anytime/entities/episode.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_html/flutter_html.dart';
 import 'package:flutter_html/style.dart';
 import 'package:url_launcher/url_launcher.dart';
@@ -28,9 +29,13 @@ class ShowNotes extends StatelessWidget {
         backgroundColor: Theme.of(context).backgroundColor,
         body: CustomScrollView(controller: _sliverScrollController, slivers: <Widget>[
           SliverAppBar(
+            backwardsCompatibility: false,
+            systemOverlayStyle: SystemUiOverlayStyle(
+              statusBarIconBrightness: Theme.of(context).brightness == Brightness.light ? Brightness.dark : Brightness.light,
+              statusBarColor: Colors.transparent,
+            ),
             brightness: Theme.of(context).brightness,
             title: Text(episode.podcast),
-            backgroundColor: Theme.of(context).appBarTheme.color,
             floating: false,
             pinned: true,
             snap: false,


### PR DESCRIPTION
This PR addresses [BU-278](https://breeztech.atlassian.net/browse/BU-278)

This change removes the need of brightness hack for the status bar blink on opening PodcastDetails page.

If the theme was overridden by the wrapping app, this hack reverted status bar color back to plugins theme. This change is to make sure the status bar color uses the overridden theme.

https://user-images.githubusercontent.com/4012752/106817659-3a9ec080-6688-11eb-8b7b-fc194dc01ad4.mp4
