### PR TITLE
Add inlineSearch feature

### DIFF
--- a/lib/ui/anytime_podcast_app.dart
+++ b/lib/ui/anytime_podcast_app.dart
@@ -179,8 +179,9 @@ class _AnytimePodcastAppState extends State<AnytimePodcastApp> {
 class AnytimeHomePage extends StatefulWidget {
   final String title;
   final bool topBarVisible;
+  final bool inlineSearch;
 
-  AnytimeHomePage({this.title, this.topBarVisible = true});
+  AnytimeHomePage({this.title, this.topBarVisible = true, this.inlineSearch = false});
 
   @override
   _AnytimeHomePageState createState() => _AnytimeHomePageState();
@@ -328,7 +329,7 @@ class _AnytimeHomePageState extends State<AnytimeHomePage> with WidgetsBindingOb
     if (index == 0) {
       return Library();
     } else if (index == 1) {
-      return Discovery();
+      return Discovery(inlineSearch: widget.inlineSearch);
     } else {
       return Downloads();
     }

--- a/lib/ui/library/discovery.dart
+++ b/lib/ui/library/discovery.dart
@@ -10,6 +10,10 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
 class Discovery extends StatefulWidget {
+  final bool inlineSearch;
+
+  Discovery({this.inlineSearch});
+
   @override
   State<StatefulWidget> createState() => _DiscoveryState();
 }
@@ -28,6 +32,6 @@ class _DiscoveryState extends State<Discovery> {
   Widget build(BuildContext context) {
     final bloc = Provider.of<DiscoveryBloc>(context);
 
-    return DiscoveryResults(data: bloc.results);
+    return DiscoveryResults(data: bloc.results, inlineSearch: widget.inlineSearch);
   }
 }

--- a/lib/ui/library/discovery_results.dart
+++ b/lib/ui/library/discovery_results.dart
@@ -7,14 +7,16 @@ import 'package:anytime/l10n/L.dart';
 import 'package:anytime/state/bloc_state.dart';
 import 'package:anytime/ui/widgets/platform_progress_indicator.dart';
 import 'package:anytime/ui/widgets/podcast_list.dart';
+import 'package:anytime/ui/widgets/podcast_list_with_search_bar.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:podcast_search/podcast_search.dart' as search;
 
 class DiscoveryResults extends StatelessWidget {
   final Stream<DiscoveryState> data;
+  final bool inlineSearch;
 
-  DiscoveryResults({@required this.data});
+  DiscoveryResults({@required this.data, this.inlineSearch});
 
   @override
   Widget build(BuildContext context) {
@@ -24,6 +26,7 @@ class DiscoveryResults extends StatelessWidget {
         final state = snapshot.data;
 
         if (state is DiscoveryPopulatedState) {
+          if (inlineSearch) return PodcastListWithSearchBar(results: state.results as search.SearchResult);
           return PodcastList(results: state.results as search.SearchResult);
         } else {
           if (state is DiscoveryLoadingState) {

--- a/lib/ui/search/search.dart
+++ b/lib/ui/search/search.dart
@@ -10,6 +10,10 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
 class Search extends StatefulWidget {
+  final String searchTerm;
+
+  Search({this.searchTerm});
+
   @override
   _SearchState createState() => _SearchState();
 }
@@ -28,6 +32,10 @@ class _SearchState extends State<Search> {
 
     _searchFocusNode = FocusNode();
     _searchController = TextEditingController();
+    if (widget.searchTerm != null) {
+      bloc.search(SearchTermEvent(widget.searchTerm));
+      _searchController.text = widget.searchTerm;
+    }
   }
 
   @override
@@ -55,7 +63,7 @@ class _SearchState extends State<Search> {
             title: TextField(
                 controller: _searchController,
                 focusNode: _searchFocusNode,
-                autofocus: true,
+                autofocus: widget.searchTerm != null ? false : true,
                 keyboardType: TextInputType.text,
                 textInputAction: TextInputAction.search,
                 decoration: InputDecoration(

--- a/lib/ui/search/search_bar.dart
+++ b/lib/ui/search/search_bar.dart
@@ -1,0 +1,49 @@
+import 'package:anytime/l10n/L.dart';
+import 'package:anytime/ui/widgets/search_slide_route.dart';
+import 'package:flutter/material.dart';
+
+import 'search.dart';
+
+class SearchBar extends StatefulWidget {
+  @override
+  _SearchBarState createState() => _SearchBarState();
+}
+
+class _SearchBarState extends State<SearchBar> {
+  TextEditingController _searchController;
+
+  @override
+  void initState() {
+    super.initState();
+    _searchController = TextEditingController();
+    _searchController.addListener(() {
+      setState(() {});
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return ListTile(
+      title: TextField(
+        controller: _searchController,
+        keyboardType: TextInputType.text,
+        textInputAction: TextInputAction.search,
+        decoration: InputDecoration(hintText: L.of(context).search_for_podcasts_hint, border: InputBorder.none),
+        style: const TextStyle(color: Colors.grey, fontSize: 18.0),
+        onSubmitted: (value) async {
+          await Navigator.push(context, SlideRightRoute(widget: Search(searchTerm: value)));
+          _searchController.clear();
+        },
+      ),
+      trailing: IconButton(
+          tooltip: L.of(context).clear_search_button_label,
+          icon: Icon(_searchController.text.isEmpty ? Icons.search : Icons.clear),
+          onPressed: _searchController.text.isEmpty
+              ? () {}
+              : () {
+                  _searchController.clear();
+                  FocusScope.of(context).requestFocus(FocusNode());
+                }),
+    );
+  }
+}

--- a/lib/ui/widgets/podcast_list_with_search_bar.dart
+++ b/lib/ui/widgets/podcast_list_with_search_bar.dart
@@ -1,0 +1,24 @@
+import 'package:anytime/ui/search/search_bar.dart';
+import 'package:anytime/ui/widgets/podcast_list.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
+import 'package:podcast_search/podcast_search.dart' as search;
+
+class PodcastListWithSearchBar extends StatelessWidget {
+  final search.SearchResult results;
+
+  const PodcastListWithSearchBar({Key key, @required this.results}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return SliverToBoxAdapter(
+      child: ShrinkWrappingViewport(
+        offset: ViewportOffset.zero(),
+        slivers: [
+          SliverToBoxAdapter(child: SearchBar()),
+          PodcastList(results: results),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
This PR addresses [BU-274](https://breeztech.atlassian.net/browse/BU-274)

If inlineSearch is enabled, search bar will be added to top of PodcastList of DiscoveryResults. This feature will be disabled by default.
SearchBar will behave similarly to Search icon on app bar except the search term can now be passed to Search view.