### PR TITLE
Use lighter text weight and slimmer icons on EpisodeTile

### DIFF
--- a/lib/ui/widgets/download_button_widget.dart
+++ b/lib/ui/widgets/download_button_widget.dart
@@ -31,7 +31,7 @@ class DownloadButton extends StatelessWidget {
         onTap: onPressed,
         child: CircularPercentIndicator(
           radius: 38.0,
-          lineWidth: 2.0,
+          lineWidth: 1.5,
           backgroundColor: Theme.of(context).buttonColor,
           progressColor: Theme.of(context).cursorColor,
           animation: true,
@@ -46,7 +46,7 @@ class DownloadButton extends StatelessWidget {
                 )
               : Icon(
                   icon,
-                  size: 28.0,
+                  size: 20.0,
                   color: Theme.of(context).buttonColor,
                 ),
         ),

--- a/lib/ui/widgets/episode_tile.dart
+++ b/lib/ui/widgets/episode_tile.dart
@@ -50,7 +50,7 @@ class EpisodeTile extends StatelessWidget {
               overflow: TextOverflow.ellipsis,
               softWrap: false,
               maxLines: 5,
-              style: Theme.of(context).textTheme.bodyText1.copyWith(fontSize: 16),
+              style: Theme.of(context).textTheme.bodyText1.copyWith(fontSize: 14, fontWeight: FontWeight.normal),
             ),
           ),
         ),
@@ -103,6 +103,7 @@ class EpisodeTile extends StatelessWidget {
                       Icon(
                         Icons.delete_outline,
                         color: Theme.of(context).buttonColor,
+                        size: 20,
                       ),
                       Padding(
                         padding: const EdgeInsets.symmetric(vertical: 2.0),
@@ -112,6 +113,7 @@ class EpisodeTile extends StatelessWidget {
                         textAlign: TextAlign.center,
                         style: TextStyle(
                           color: Theme.of(context).buttonColor,
+                          fontWeight: FontWeight.normal,
                         ),
                       ),
                     ],
@@ -138,6 +140,7 @@ class EpisodeTile extends StatelessWidget {
                       Icon(
                         Icons.wysiwyg_outlined,
                         color: Theme.of(context).buttonColor,
+                        size: 20,
                       ),
                       Padding(
                         padding: const EdgeInsets.symmetric(vertical: 2.0),
@@ -147,6 +150,7 @@ class EpisodeTile extends StatelessWidget {
                         textAlign: TextAlign.center,
                         style: TextStyle(
                           color: Theme.of(context).buttonColor,
+                          fontWeight: FontWeight.normal,
                         ),
                       ),
                     ],
@@ -167,6 +171,7 @@ class EpisodeTile extends StatelessWidget {
                       Icon(
                         Icons.bookmark_border_outlined,
                         color: Theme.of(context).buttonColor,
+                        size: 20,
                       ),
                       Padding(
                         padding: const EdgeInsets.symmetric(vertical: 2.0),
@@ -176,6 +181,7 @@ class EpisodeTile extends StatelessWidget {
                         textAlign: TextAlign.center,
                         style: TextStyle(
                           color: Theme.of(context).buttonColor,
+                          fontWeight: FontWeight.normal,
                         ),
                       ),
                     ],
@@ -245,7 +251,7 @@ class EpisodeTile extends StatelessWidget {
           overflow: TextOverflow.ellipsis,
           maxLines: 2,
           softWrap: false,
-          style: textTheme.bodyText2.copyWith(fontWeight: FontWeight.bold),
+          style: textTheme.bodyText2.copyWith(fontWeight: FontWeight.normal),
         ),
       ),
     );

--- a/lib/ui/widgets/play_pause_button_widget.dart
+++ b/lib/ui/widgets/play_pause_button_widget.dart
@@ -24,12 +24,12 @@ class PlayPauseButton extends StatelessWidget {
       label: '$label $title',
       child: CircularPercentIndicator(
         radius: 38.0,
-        lineWidth: 2.0,
+        lineWidth: 1.5,
         backgroundColor: Theme.of(context).buttonColor,
         percent: 0.0,
         center: Icon(
           icon,
-          size: 28.0,
+          size: 20.0,
           color: Theme.of(context).buttonColor,
         ),
       ),
@@ -61,17 +61,17 @@ class PlayPauseBusyButton extends StatelessWidget {
             children: <Widget>[
               CircularPercentIndicator(
                 radius: 38.0,
-                lineWidth: 2.0,
+                lineWidth: 1.5,
                 backgroundColor: Colors.white,
                 percent: 0.0,
                 center: Icon(
                   icon,
-                  size: 28.0,
+                  size: 20.0,
                   color: Colors.orange,
                 ),
               ),
               const SpinKitRing(
-                lineWidth: 2.0,
+                lineWidth: 1.5,
                 color: Colors.blue,
                 size: 38.0,
               ),


### PR DESCRIPTION
This PR addresses [BU-283](https://breeztech.atlassian.net/browse/BU-283)

- Episode title is no longer bold.
- Episode description is now the same font size with podcast description text. _It used to be larger._
- The download & play buttons lineWidth and their icon size is reduced.
- Delete, Show Notes and Mark Played text and icon size are reduced.