### PR TITLE
Fix system navigation bar color on light theme

### DIFF
--- a/lib/ui/anytime_podcast_app.dart
+++ b/lib/ui/anytime_podcast_app.dart
@@ -247,11 +247,14 @@ class _AnytimeHomePageState extends State<AnytimeHomePage> {
     final pager = Provider.of<PagerBloc>(context);
     var settings = Provider.of<SettingsBloc>(context).currentSettings;
     final backgroundColour = Theme.of(context).scaffoldBackgroundColor;
+    final isLight = Theme.of(context).brightness == Brightness.light;
 
     return AnnotatedRegion<SystemUiOverlayStyle>(
       value: SystemUiOverlayStyle(
-        statusBarIconBrightness: Theme.of(context).brightness == Brightness.light ? Brightness.dark : Brightness.light,
-        systemNavigationBarColor: Theme.of(context).bottomAppBarColor,
+        statusBarIconBrightness: isLight ? Brightness.dark : Brightness.light,
+        systemNavigationBarColor: isLight
+            ? Theme.of(context).primaryColorDark
+            : Theme.of(context).bottomAppBarColor,
         statusBarColor: Colors.transparent,
       ),
       child: Scaffold(


### PR DESCRIPTION
Android system navigation bar on the light theme has the wrong background color, this MR fixes it.

# After

|||||
|---|---|---|---|
|![Screenshot_20210916-095113_Anytime_Player](https://user-images.githubusercontent.com/1225438/133615812-b6d35fe4-a45d-43a5-b97c-f5931070adb8.png)|![Screenshot_20210916-095100_Anytime_Player](https://user-images.githubusercontent.com/1225438/133615810-8accccd8-ab16-4615-bc16-0ba41d01d233.png)|![Screenshot_20210916-095025_Anytime_Player](https://user-images.githubusercontent.com/1225438/133615807-50f8c295-6f7d-4ed6-8fe5-b32d1ad3e20b.png)|![Screenshot_20210916-095005_Anytime_Player](https://user-images.githubusercontent.com/1225438/133615802-694add42-3bc0-4ec3-b1d8-10bfb8f93c2f.png)|


# Before

|||||
|---|---|---|---|
|![Screenshot_20210916-095706_Anytime_Player](https://user-images.githubusercontent.com/1225438/133616813-51858938-c406-4c71-bf0c-5126b39c0f91.png)|![Screenshot_20210916-095658_Anytime_Player](https://user-images.githubusercontent.com/1225438/133616808-31c92e47-88db-4b55-93d5-50805e031bb4.png)|![Screenshot_20210916-095732_Anytime_Player](https://user-images.githubusercontent.com/1225438/133616818-6feaffab-876b-4a41-bf2a-5320e2e937af.png)|![Screenshot_20210916-095722_Anytime_Player](https://user-images.githubusercontent.com/1225438/133616815-91d65ef7-935a-45dc-b5ac-7bec5ccbc0da.png)|
