### PR TITLE
Fix sleep timer when user select different minutes and improve snack bar feedback

### DIFF
--- a/lib/bloc/podcast/audio_bloc.dart
+++ b/lib/bloc/podcast/audio_bloc.dart
@@ -102,7 +102,7 @@ class AudioBloc extends Bloc {
   /// underlying audio service.
   void _handleEpisodeRequests() async {
     _play.listen((episode) {
-      changeSleepPolicy(sleepPolicyNotSet());
+      _turnSleepPolicyOff();
       audioPlayerService.playEpisode(episode: episode, resume: true);
     });
   }
@@ -136,7 +136,6 @@ class AudioBloc extends Bloc {
 
   void _turnSleepPolicyOff() async {
     final current = await _sleepPolicy.first;
-    if (current is SleepPolicyNotSet) return;
     if (current is SleepPolicyOff) return;
     changeSleepPolicy(sleepPolicyOff());
   }

--- a/lib/bloc/podcast/audio_bloc.dart
+++ b/lib/bloc/podcast/audio_bloc.dart
@@ -122,7 +122,7 @@ class AudioBloc extends Bloc {
 
   void _handleSleepPolicyChanges() {
     _sleepPolicy.listen((SleepPolicy policy) async {
-      log.fine('Policy changed o $policy');
+      log.fine('Policy changed to $policy');
       if (policy is SleepPolicyTimer) {
         await Future<void>.delayed(policy.duration).then((_) async {
           final current = await _sleepPolicy.first;

--- a/lib/state/sleep_policy.dart
+++ b/lib/state/sleep_policy.dart
@@ -1,13 +1,16 @@
-abstract class SleepPolicy {}
+abstract class SleepPolicy {
+  bool feedbackGiven;
 
-class SleepPolicyNotSet extends SleepPolicy {
-  @override
-  bool operator ==(Object other) {
-    return other is SleepPolicyNotSet;
-  }
+  SleepPolicy(
+    this.feedbackGiven,
+  );
 }
 
 class SleepPolicyOff extends SleepPolicy {
+  SleepPolicyOff(
+    bool feedbackGiven,
+  ) : super(feedbackGiven);
+
   @override
   bool operator ==(Object other) {
     return other is SleepPolicyOff;
@@ -21,7 +24,8 @@ class SleepPolicyTimer extends SleepPolicy {
   SleepPolicyTimer(
     this.duration,
     this._millisecond,
-  );
+    bool feedbackGiven,
+  ) : super(feedbackGiven);
 
   @override
   bool operator ==(Object other) {
@@ -36,11 +40,11 @@ class SleepPolicyTimer extends SleepPolicy {
   }
 }
 
-SleepPolicy sleepPolicyNotSet() => SleepPolicyNotSet();
-
-SleepPolicy sleepPolicyOff() => SleepPolicyOff();
+SleepPolicy sleepPolicyOff([bool feedbackGiven = false]) =>
+    SleepPolicyOff(feedbackGiven);
 
 SleepPolicy sleepPolicyMinutes(int minutes) => SleepPolicyTimer(
       Duration(minutes: minutes),
       DateTime.now().millisecondsSinceEpoch,
+      false,
     );

--- a/lib/state/sleep_policy.dart
+++ b/lib/state/sleep_policy.dart
@@ -16,19 +16,23 @@ class SleepPolicyOff extends SleepPolicy {
 
 class SleepPolicyTimer extends SleepPolicy {
   final Duration duration;
+  final int _millisecond;
 
   SleepPolicyTimer(
     this.duration,
+    this._millisecond,
   );
 
   @override
   bool operator ==(Object other) {
-    return other is SleepPolicyTimer && other.duration == duration;
+    return other is SleepPolicyTimer &&
+        other.duration == duration &&
+        other._millisecond == _millisecond;
   }
 
   @override
   String toString() {
-    return 'SleepPolicyTimer($duration)';
+    return 'SleepPolicyTimer($duration, $_millisecond)';
   }
 }
 
@@ -38,4 +42,5 @@ SleepPolicy sleepPolicyOff() => SleepPolicyOff();
 
 SleepPolicy sleepPolicyMinutes(int minutes) => SleepPolicyTimer(
       Duration(minutes: minutes),
+      DateTime.now().millisecondsSinceEpoch,
     );

--- a/lib/ui/podcast/now_playing.dart
+++ b/lib/ui/podcast/now_playing.dart
@@ -57,7 +57,7 @@ class _NowPlayingState extends State<NowPlaying> with WidgetsBindingObserver {
     });
 
     audioBloc.sleepPolicy
-        .where((policy) => !(policy is SleepPolicyNotSet))
+        .where((policy) => !policy.feedbackGiven)
         .listen((policy) => _policyChanged(policy));
   }
 
@@ -147,6 +147,7 @@ class _NowPlayingState extends State<NowPlaying> with WidgetsBindingObserver {
           ),
         ),
       );
+      policy.feedbackGiven = true;
     }
   }
 }

--- a/lib/ui/widgets/sleep_selector.dart
+++ b/lib/ui/widgets/sleep_selector.dart
@@ -28,7 +28,7 @@ class SleepSelector extends StatelessWidget {
     return StreamBuilder<SleepPolicy>(
       stream: audioBloc.sleepPolicy,
       builder: (context, snapshot) {
-        final sleepPolicy = snapshot.data ?? sleepPolicyNotSet();
+        final sleepPolicy = snapshot.data ?? sleepPolicyOff(true);
         return IconButton(
           tooltip: texts.sleep_episode_function_header,
           constraints: constraints,
@@ -107,8 +107,7 @@ class SleepSelector extends StatelessWidget {
 
   List<SleepOption> sleepOptions(L texts, SleepPolicy sleepPolicy) {
     var options = <SleepOption>[];
-    if (!(sleepPolicy is SleepPolicyOff) &&
-        !(sleepPolicy is SleepPolicyNotSet)) {
+    if (!(sleepPolicy is SleepPolicyOff)) {
       options.add(SleepOption(
         texts.sleep_episode_function_turn_off,
         sleepPolicyOff(),
@@ -182,7 +181,7 @@ class SleepSelector extends StatelessWidget {
   }
 
   Widget _icon(ThemeData theme, SleepPolicy sleepPolicy) {
-    if (sleepPolicy is SleepPolicyOff || sleepPolicy is SleepPolicyNotSet) {
+    if (sleepPolicy is SleepPolicyOff) {
       return iconOff ??
           Icon(
             Icons.nightlight_outlined,


### PR DESCRIPTION
- Makes sure the snack bar shows only once
- Shows the snack bar (timer off) if the user changes episode
- fix the bug when the user select sleep timer as follow:
  - Select X minutes
  - Select Y minutes
  - Select X minutes (again)
