### PR TITLE
Fix sleep timer

### DIFF
--- a/lib/bloc/podcast/audio_bloc.dart
+++ b/lib/bloc/podcast/audio_bloc.dart
@@ -145,6 +145,7 @@ class AudioBloc extends Bloc {
   }
 
   void _handleSleepPolicyChanges() {
+    changeSleepPolicy(sleepPolicyOff(true));
     _sleepPolicy.listen((SleepPolicy policy) async {
       log.fine('Policy changed to $policy');
       if (policy is SleepPolicyTimer) {


### PR DESCRIPTION
The first time the AudioBloc is created it set the timer off to fix an unwanted delayed effect on the following line that turns off the sleep timer as soon as the first sleep option is set.

https://github.com/breez/anytime_podcast_player/blob/eb5e92f8b37215706eed912f572910dc0c7a5bbb/lib/bloc/podcast/audio_bloc.dart#L162

The bug:

https://user-images.githubusercontent.com/1225438/147689716-8f28952b-7678-49a1-bd2d-3b1a9b7624ef.mp4


