### PR TITLE
Display warning dialog for non-secure connection downloads

### DIFF
--- a/lib/l10n/L.dart
+++ b/lib/l10n/L.dart
@@ -889,84 +889,102 @@ class L {
   }
 
   String get sleep_episode_function_header {
-    return Intl.message(
-      'Stop audio in',
-      name: 'sleep_episode_function_header',
-      desc: '',
-      args: [],
-    );
+    return message('sleep_episode_function_header') ??
+        Intl.message(
+          'Stop audio in',
+          name: 'sleep_episode_function_header',
+          desc: 'Title for Sleep Selector',
+          args: [],
+          locale: localeName,
+        );
   }
 
   String get sleep_episode_function_turn_off {
-    return Intl.message(
-      'Turn off timer',
-      name: 'sleep_episode_function_turn_off',
-      desc: '',
-      args: [],
-    );
+    return message('sleep_episode_function_turn_off') ??
+        Intl.message(
+          'Turn off timer',
+          name: 'sleep_episode_function_turn_off',
+          desc: 'Label for turning off sleep timer',
+          args: [],
+          locale: localeName,
+        );
   }
 
   String get sleep_episode_function_toggled_on {
-    return Intl.message(
-      'Your sleep timer is set',
-      name: 'sleep_episode_function_toggled_on',
-      desc: '',
-      args: [],
-    );
+    return message('sleep_episode_function_toggled_on') ??
+        Intl.message(
+          'Your sleep timer is set',
+          name: 'sleep_episode_function_toggled_on',
+          desc: 'Label for toggling on sleep timer',
+          args: [],
+          locale: localeName,
+        );
   }
 
   String get sleep_episode_function_toggled_off {
-    return Intl.message(
-      'Your sleep timer is turned off',
-      name: 'sleep_episode_function_toggled_off',
-      desc: '',
-      args: [],
-    );
+    return message('sleep_episode_function_toggled_off') ??
+        Intl.message(
+          'Your sleep timer is turned off',
+          name: 'sleep_episode_function_toggled_off',
+          desc: 'Label for toggling off sleep timer',
+          args: [],
+          locale: localeName,
+        );
   }
 
   String get sleep_episode_function_5_minutes {
-    return Intl.message(
-      '5 minutes',
-      name: 'sleep_episode_function_5_minutes',
-      desc: '',
-      args: [],
-    );
+    return message('sleep_episode_function_5_minutes') ??
+        Intl.message(
+          '5 minutes',
+          name: 'sleep_episode_function_5_minutes',
+          desc: '',
+          args: [],
+          locale: localeName,
+        );
   }
 
   String get sleep_episode_function_15_minutes {
-    return Intl.message(
-      '15 minutes',
-      name: 'sleep_episode_function_15_minutes',
-      desc: '',
-      args: [],
-    );
+    return message('sleep_episode_function_15_minutes') ??
+        Intl.message(
+          '15 minutes',
+          name: 'sleep_episode_function_15_minutes',
+          desc: '',
+          args: [],
+          locale: localeName,
+        );
   }
 
   String get sleep_episode_function_30_minutes {
-    return Intl.message(
-      '30 minutes',
-      name: 'sleep_episode_function_30_minutes',
-      desc: '',
-      args: [],
-    );
+    return message('sleep_episode_function_30_minutes') ??
+        Intl.message(
+          '30 minutes',
+          name: 'sleep_episode_function_30_minutes',
+          desc: '',
+          args: [],
+          locale: localeName,
+        );
   }
 
   String get sleep_episode_function_45_minutes {
-    return Intl.message(
-      '45 minutes',
-      name: 'sleep_episode_function_45_minutes',
-      desc: '',
-      args: [],
-    );
+    return message('sleep_episode_function_45_minutes') ??
+        Intl.message(
+          '45 minutes',
+          name: 'sleep_episode_function_45_minutes',
+          desc: '',
+          args: [],
+          locale: localeName,
+        );
   }
 
   String get sleep_episode_function_60_minutes {
-    return Intl.message(
-      '1 hour',
-      name: 'sleep_episode_function_60_minutes',
-      desc: '',
-      args: [],
-    );
+    return message('sleep_episode_function_60_minutes') ??
+        Intl.message(
+          '1 hour',
+          name: 'sleep_episode_function_60_minutes',
+          desc: '',
+          args: [],
+          locale: localeName,
+        );
   }
 
   String get empty_queue_message {
@@ -1105,6 +1123,36 @@ class L {
           'Layout',
           name: 'layout_label',
           desc: 'Layout menu label',
+          locale: localeName,
+        );
+  }
+
+  String get proceed_button_label {
+    return message('proceed_button_label') ??
+        Intl.message(
+          'Proceed anyway',
+          name: 'proceed_button_label',
+          desc: 'Shown on dialog box when accepting non-secure connection download',
+          locale: localeName,
+        );
+  }
+
+  String get non_secure_connection_dialog_header {
+    return message('non_secure_connection_dialog_header') ??
+        Intl.message(
+          'Your connection is not private',
+          name: 'non_secure_connection_dialog_header',
+          desc: 'Header on non-secure connection warning dialog',
+          locale: localeName,
+        );
+  }
+
+  String get non_secure_connection_message {
+    return message('non_secure_connection_message') ??
+        Intl.message(
+          "The site isn't using a private connection. Someone might be able to see or change the information you send or get through this site. Contact the site owner to ask that they secure the site and your data with HTTPS.",
+          name: 'non_secure_connection_message',
+          desc: 'Displayed on non-secure connection warning dialog',
           locale: localeName,
         );
   }

--- a/lib/l10n/intl_de.arb
+++ b/lib/l10n/intl_de.arb
@@ -595,5 +595,17 @@
     "type": "text",
     "placeholders_order": [],
     "placeholders": {}
-  }
+  },
+  "sleep_episode_function_header": "Ausschalten nach",
+  "sleep_episode_function_turn_off": "Timer ausschalten",
+  "sleep_episode_function_toggled_on": "Dein Sleeptimer ist eingestellt",
+  "sleep_episode_function_toggled_off": "Dein Sleeptimer ist ausgeschaltet",
+  "sleep_episode_function_5_minutes": "5 Minuten",
+  "sleep_episode_function_15_minutes": "15 Minuten",
+  "sleep_episode_function_30_minutes": "30 Minuten",
+  "sleep_episode_function_45_minutes": "45 Minuten",
+  "sleep_episode_function_60_minutes": "1 Stunde",
+  "proceed_button_label": "Trotzdem fortfahren",
+  "non_secure_connection_dialog_header": "Ihre Verbindung ist nicht privat",
+  "non_secure_connection_message": "Die Website nutzt keine private Verbindung. Es ist möglich, dass eine unbefugte Person Zugriff auf Informationen erhält, die Sie an die Website gesendet haben oder die Ihnen von der Website übermittelt wurden, und diese ändern kann. Wenden Sie sich an den Inhaber der Website und bitten Sie ihn, die Website und Ihre Daten mit HTTPS zu sichern.",
 }

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -596,8 +596,7 @@
     "type": "text",
     "placeholders_order": [],
     "placeholders": {}
-  }
-}
+  },
   "sleep_episode_function_header": "Sleep after",
   "sleep_episode_function_turn_off": "Turn off timer",
   "sleep_episode_function_toggled_on": "Your sleep timer is on.",
@@ -607,4 +606,7 @@
   "sleep_episode_function_30_minutes": "30 minutes",
   "sleep_episode_function_45_minutes": "45 minutes",
   "sleep_episode_function_60_minutes": "1 hour",
+  "proceed_button_label": "Proceed anyway",
+  "non_secure_connection_dialog_header": "Your connection is not private",
+  "non_secure_connection_message": "The site isn't using a private connection. Someone might be able to see or change the information you send or get through this site. Contact the site owner to ask that they secure the site and your data with HTTPS.",
 }

--- a/lib/l10n/intl_messages.arb
+++ b/lib/l10n/intl_messages.arb
@@ -685,5 +685,17 @@
     "type": "text",
     "placeholders_order": [],
     "placeholders": {}
-  }
+  },
+  "sleep_episode_function_header": "Sleep after",
+  "sleep_episode_function_turn_off": "Turn off timer",
+  "sleep_episode_function_toggled_on": "Your sleep timer is on.",
+  "sleep_episode_function_toggled_off": "Your sleep timer is off.",
+  "sleep_episode_function_5_minutes": "5 minutes",
+  "sleep_episode_function_15_minutes": "15 minutes",
+  "sleep_episode_function_30_minutes": "30 minutes",
+  "sleep_episode_function_45_minutes": "45 minutes",
+  "sleep_episode_function_60_minutes": "1 hour",
+  "proceed_button_label": "Proceed anyway",
+  "non_secure_connection_dialog_header": "Your connection is not private",
+  "non_secure_connection_message": "The site isn't using a private connection. Someone might be able to see or change the information you send or get through this site. Contact the site owner to ask that they secure the site and your data with HTTPS.",
 }

--- a/lib/l10n/intl_pt.arb
+++ b/lib/l10n/intl_pt.arb
@@ -375,7 +375,7 @@
   "sleep_episode_function_30_minutes": "30 minutos",
   "sleep_episode_function_45_minutes": "45 minutos",
   "sleep_episode_function_60_minutes": "1 hora",
-  "proceed_button_label": "Prosseguir",
-  "non_secure_connection_dialog_header": "Sua conexão não é particular",
-  "non_secure_connection_message": "Este site não está a utilizar uma ligação privada. Alguém pode conseguir ver ou alterar as informações que enviar ou receber através deste site. Contacte o proprietário do site e peça-lhe que proteja o site e os seus dados com HTTPS.",
+  "proceed_button_label": "Prosseguir assim mesmo",
+  "non_secure_connection_dialog_header": "Sua conexão não é segura",
+  "non_secure_connection_message": "Este site não está utilizando uma conexão privada. Alguém pode conseguir ver ou alterar as informações trafegadas por esta conexão. Contacte o administrador do site e peça-lhe que proteja a conexão e os seus dados com HTTPS.",
 }

--- a/lib/l10n/intl_pt.arb
+++ b/lib/l10n/intl_pt.arb
@@ -375,4 +375,7 @@
   "sleep_episode_function_30_minutes": "30 minutos",
   "sleep_episode_function_45_minutes": "45 minutos",
   "sleep_episode_function_60_minutes": "1 hora",
+  "proceed_button_label": "Prosseguir",
+  "non_secure_connection_dialog_header": "Sua conexão não é particular",
+  "non_secure_connection_message": "Este site não está a utilizar uma ligação privada. Alguém pode conseguir ver ou alterar as informações que enviar ou receber através deste site. Contacte o proprietário do site e peça-lhe que proteja o site e os seus dados com HTTPS.",
 }

--- a/lib/l10n/messages_de.dart
+++ b/lib/l10n/messages_de.dart
@@ -126,6 +126,15 @@ class MessageLookup extends MessageLookupByLibrary {
         "settings_playback_divider_label": MessageLookupByLibrary.simpleMessage("WIEDERGABE"),
         "settings_theme_switch_label": MessageLookupByLibrary.simpleMessage("Dark theme"),
         "show_notes_label": MessageLookupByLibrary.simpleMessage("Notizen anzeigen"),
+        "sleep_episode_function_5_minutes" : MessageLookupByLibrary.simpleMessage("5 Minuten"),
+        "sleep_episode_function_15_minutes" : MessageLookupByLibrary.simpleMessage("15 Minuten"),
+        "sleep_episode_function_30_minutes" : MessageLookupByLibrary.simpleMessage("30 Minuten"),
+        "sleep_episode_function_45_minutes" : MessageLookupByLibrary.simpleMessage("45 Minuten"),
+        "sleep_episode_function_60_minutes" : MessageLookupByLibrary.simpleMessage("1 Stunde"),
+        "sleep_episode_function_header" : MessageLookupByLibrary.simpleMessage("Ausschalten nach"),
+        "sleep_episode_function_toggled_off" : MessageLookupByLibrary.simpleMessage("Dein Sleeptimer ist ausgeschaltet"),
+        "sleep_episode_function_toggled_on" : MessageLookupByLibrary.simpleMessage("Dein Sleeptimer ist eingestellt"),
+        "sleep_episode_function_turn_off" : MessageLookupByLibrary.simpleMessage("Timer ausschalten"),
         "stop_download_button_label": MessageLookupByLibrary.simpleMessage("Halt"),
         "stop_download_confirmation": MessageLookupByLibrary.simpleMessage(
             "Möchten Sie diesen Download wirklich beenden und die Episode löschen?"),
@@ -136,6 +145,9 @@ class MessageLookup extends MessageLookupByLibrary {
         "unsubscribe_label": MessageLookupByLibrary.simpleMessage("Nicht mehr folgen"),
         "unsubscribe_message": MessageLookupByLibrary.simpleMessage(
             "Wenn Sie nicht mehr folgen, werden alle heruntergeladenen Folgen dieses Podcasts gelöscht."),
-        "up_next_queue_label": MessageLookupByLibrary.simpleMessage("Als nächstes")
+        "up_next_queue_label": MessageLookupByLibrary.simpleMessage("Als nächstes"),
+        "proceed_button_label": MessageLookupByLibrary.simpleMessage("Trotzdem fortfahren"),
+        "non_secure_connection_dialog_header": MessageLookupByLibrary.simpleMessage("Ihre Verbindung ist nicht privat"),
+        "non_secure_connection_message": MessageLookupByLibrary.simpleMessage("Die Website nutzt keine private Verbindung. Es ist möglich, dass eine unbefugte Person Zugriff auf Informationen erhält, die Sie an die Website gesendet haben oder die Ihnen von der Website übermittelt wurden, und diese ändern kann. Wenden Sie sich an den Inhaber der Website und bitten Sie ihn, die Website und Ihre Daten mit HTTPS zu sichern.")
       };
 }

--- a/lib/l10n/messages_en.dart
+++ b/lib/l10n/messages_en.dart
@@ -137,6 +137,9 @@ class MessageLookup extends MessageLookupByLibrary {
         "unsubscribe_label": MessageLookupByLibrary.simpleMessage("Unfollow"),
         "unsubscribe_message":
             MessageLookupByLibrary.simpleMessage("Unfollowing will delete all downloaded episodes of this podcast."),
-        "up_next_queue_label": MessageLookupByLibrary.simpleMessage("Up Next")
+        "up_next_queue_label": MessageLookupByLibrary.simpleMessage("Up Next"),
+        "proceed_button_label": MessageLookupByLibrary.simpleMessage("Proceed anyway"),
+        "non_secure_connection_dialog_header": MessageLookupByLibrary.simpleMessage("Your connection is not private"),
+        "non_secure_connection_message": MessageLookupByLibrary.simpleMessage("The site isn't using a private connection. Someone might be able to see or change the information you send or get through this site. Contact the site owner to ask that they secure the site and your data with HTTPS.")
       };
 }

--- a/lib/l10n/messages_messages.dart
+++ b/lib/l10n/messages_messages.dart
@@ -130,6 +130,9 @@ class MessageLookup extends MessageLookupByLibrary {
         "unsubscribe_label": MessageLookupByLibrary.simpleMessage("Unsubscribe"),
         "unsubscribe_message":
             MessageLookupByLibrary.simpleMessage("Unsubscribing will delete all downloaded episodes of this podcast."),
-        "up_next_queue_label": MessageLookupByLibrary.simpleMessage("Up Next")
+        "up_next_queue_label": MessageLookupByLibrary.simpleMessage("Up Next"),
+        "proceed_button_label": MessageLookupByLibrary.simpleMessage("Proceed anyway"),
+        "non_secure_connection_dialog_header": MessageLookupByLibrary.simpleMessage("Your connection is not private"),
+        "non_secure_connection_message": MessageLookupByLibrary.simpleMessage("The site isn't using a private connection. Someone might be able to see or change the information you send or get through this site. Contact the site owner to ask that they secure the site and your data with HTTPS.")
       };
 }

--- a/lib/l10n/messages_pt.dart
+++ b/lib/l10n/messages_pt.dart
@@ -91,6 +91,10 @@ class MessageLookup extends MessageLookupByLibrary {
     "subscribe_label" : MessageLookupByLibrary.simpleMessage("Seguir"),
     "unsubscribe_button_label" : MessageLookupByLibrary.simpleMessage("NÃO SEGUIR"),
     "unsubscribe_label" : MessageLookupByLibrary.simpleMessage("Não Seguir"),
-    "unsubscribe_message" : MessageLookupByLibrary.simpleMessage("Ao não seguir mais este podcast todos os episódios baixados serão deletados.")
+    "unsubscribe_message" : MessageLookupByLibrary.simpleMessage("Ao não seguir mais este podcast todos os episódios baixados serão deletados."),
+    "up_next_queue_label": MessageLookupByLibrary.simpleMessage("A Seguir"),
+    "proceed_button_label": MessageLookupByLibrary.simpleMessage("Prosseguir"),
+    "non_secure_connection_dialog_header": MessageLookupByLibrary.simpleMessage("Sua conexão não é particular"),
+    "non_secure_connection_message": MessageLookupByLibrary.simpleMessage("Este site não está a utilizar uma ligação privada. Alguém pode conseguir ver ou alterar as informações que enviar ou receber através deste site. Contacte o proprietário do site e peça-lhe que proteja o site e os seus dados com HTTPS.")
   };
 }

--- a/lib/l10n/messages_pt.dart
+++ b/lib/l10n/messages_pt.dart
@@ -93,8 +93,8 @@ class MessageLookup extends MessageLookupByLibrary {
     "unsubscribe_label" : MessageLookupByLibrary.simpleMessage("Não Seguir"),
     "unsubscribe_message" : MessageLookupByLibrary.simpleMessage("Ao não seguir mais este podcast todos os episódios baixados serão deletados."),
     "up_next_queue_label": MessageLookupByLibrary.simpleMessage("A Seguir"),
-    "proceed_button_label": MessageLookupByLibrary.simpleMessage("Prosseguir"),
-    "non_secure_connection_dialog_header": MessageLookupByLibrary.simpleMessage("Sua conexão não é particular"),
-    "non_secure_connection_message": MessageLookupByLibrary.simpleMessage("Este site não está a utilizar uma ligação privada. Alguém pode conseguir ver ou alterar as informações que enviar ou receber através deste site. Contacte o proprietário do site e peça-lhe que proteja o site e os seus dados com HTTPS.")
+    "proceed_button_label": MessageLookupByLibrary.simpleMessage("Prosseguir assim mesmo"),
+    "non_secure_connection_dialog_header": MessageLookupByLibrary.simpleMessage("Sua conexão não é segura"),
+    "non_secure_connection_message": MessageLookupByLibrary.simpleMessage("Este site não está utilizando uma conexão privada. Alguém pode conseguir ver ou alterar as informações trafegadas por esta conexão. Contacte o administrador do site e peça-lhe que proteja a conexão e os seus dados com HTTPS.")
   };
 }

--- a/lib/ui/podcast/transport_controls.dart
+++ b/lib/ui/podcast/transport_controls.dart
@@ -223,7 +223,13 @@ class DownloadControl extends StatelessWidget {
           }
 
           return DownloadButton(
-            onPressed: () => podcastBloc.downloadEpisode(episode),
+            onPressed: () {
+              if (episode.contentUrl.startsWith('http:')) {
+                _showWarningDialog(context, podcastBloc);
+              } else {
+                podcastBloc.downloadEpisode(episode);
+              }
+            },
             title: episode.title,
             icon: Icons.save_alt,
             percent: 0,
@@ -259,6 +265,40 @@ class DownloadControl extends StatelessWidget {
             iosIsDefaultAction: true,
             onPressed: () {
               episodeBloc.deleteDownload(episode);
+              Navigator.pop(context);
+            },
+          ),
+        ],
+      ),
+    );
+  }
+
+  Future<void> _showWarningDialog(BuildContext context, PodcastBloc podcastBloc) {
+    return showDialog<void>(
+      context: context,
+      useRootNavigator: false,
+      builder: (_) => BasicDialogAlert(
+        title: Text(
+          'Your connection is not private',
+        ),
+        content: Text(
+            "The site isn't using a private connection. Someone might be able to see or change the information you send or get through this site. Contact the site owner to ask that they secure the site and your data with HTTPS."),
+        actions: <Widget>[
+          BasicDialogAction(
+            title: Text(
+              L.of(context).cancel_button_label,
+            ),
+            onPressed: () {
+              Navigator.pop(context);
+            },
+          ),
+          BasicDialogAction(
+            title: Text(
+              'Proceed anyway',
+            ),
+            iosIsDefaultAction: true,
+            onPressed: () {
+              podcastBloc.downloadEpisode(episode);
               Navigator.pop(context);
             },
           ),

--- a/lib/ui/podcast/transport_controls.dart
+++ b/lib/ui/podcast/transport_controls.dart
@@ -300,11 +300,8 @@ class DownloadControl extends StatelessWidget {
       context: context,
       useRootNavigator: false,
       builder: (_) => BasicDialogAlert(
-        title: Text(
-          'Your connection is not private',
-        ),
-        content: Text(
-            "The site isn't using a private connection. Someone might be able to see or change the information you send or get through this site. Contact the site owner to ask that they secure the site and your data with HTTPS."),
+        title: Text(L.of(context).non_secure_connection_dialog_header),
+        content: Text(L.of(context).non_secure_connection_message),
         actions: <Widget>[
           BasicDialogAction(
             title: Text(
@@ -315,9 +312,7 @@ class DownloadControl extends StatelessWidget {
             },
           ),
           BasicDialogAction(
-            title: Text(
-              'Proceed anyway',
-            ),
+            title: Text(L.of(context).proceed_button_label),
             iosIsDefaultAction: true,
             onPressed: () {
               podcastBloc.downloadEpisode(episode);


### PR DESCRIPTION
Some podcasts serve their episodes on non-SSL servers. Downloading these episodes fail after download URL is resolved to be non-secure by `FlutterDownloader` unless it is initialized with `ignoreSsl: true`. Currently there's no feedback as to why download stops on UI layer to the user.

We suggest enabling `ignoreSsl`(on parent app layer) and displaying a warning dialog for downloads from non-SSL links, prompting user to proceed at their own risk. There are secure links that redirect to non-secure links, vice versa. We're only checking if the final redirected url is resolved to be non-secure before displaying the warning dialog.

#### L10N Changes:
- Added non-secure connection dialog related translations
- **[Out of Context]** Fixed formatting of `lib/l10n/intl_en.arb` and added missing translations for `SleepSelector` in German.
- Added fallback for SleepSelector translations