### PR TITLE
Implement end of episode sleep policy

### DIFF
--- a/lib/l10n/L.dart
+++ b/lib/l10n/L.dart
@@ -932,6 +932,17 @@ class L {
         );
   }
 
+  String get sleep_episode_function_end_of_episode {
+    return message('sleep_episode_function_end_of_episode') ??
+        Intl.message(
+          'End of episode',
+          name: 'sleep_episode_function_end_of_episode',
+          desc: '',
+          args: [],
+          locale: localeName,
+        );
+  }
+
   String get sleep_episode_function_5_minutes {
     return message('sleep_episode_function_5_minutes') ??
         Intl.message(

--- a/lib/l10n/intl_de.arb
+++ b/lib/l10n/intl_de.arb
@@ -600,6 +600,7 @@
   "sleep_episode_function_turn_off": "Timer ausschalten",
   "sleep_episode_function_toggled_on": "Dein Sleeptimer ist eingestellt",
   "sleep_episode_function_toggled_off": "Dein Sleeptimer ist ausgeschaltet",
+  "sleep_episode_function_end_of_episode": "Ende von episode",
   "sleep_episode_function_5_minutes": "5 Minuten",
   "sleep_episode_function_15_minutes": "15 Minuten",
   "sleep_episode_function_30_minutes": "30 Minuten",

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -601,6 +601,7 @@
   "sleep_episode_function_turn_off": "Turn off timer",
   "sleep_episode_function_toggled_on": "Your sleep timer is on.",
   "sleep_episode_function_toggled_off": "Your sleep timer is off.",
+  "sleep_episode_function_end_of_episode": "End of Episode",
   "sleep_episode_function_5_minutes": "5 minutes",
   "sleep_episode_function_15_minutes": "15 minutes",
   "sleep_episode_function_30_minutes": "30 minutes",

--- a/lib/l10n/intl_messages.arb
+++ b/lib/l10n/intl_messages.arb
@@ -690,6 +690,7 @@
   "sleep_episode_function_turn_off": "Turn off timer",
   "sleep_episode_function_toggled_on": "Your sleep timer is on.",
   "sleep_episode_function_toggled_off": "Your sleep timer is off.",
+  "sleep_episode_function_end_of_episode": "End of episode",
   "sleep_episode_function_5_minutes": "5 minutes",
   "sleep_episode_function_15_minutes": "15 minutes",
   "sleep_episode_function_30_minutes": "30 minutes",

--- a/lib/l10n/intl_pt.arb
+++ b/lib/l10n/intl_pt.arb
@@ -370,6 +370,7 @@
   "sleep_episode_function_turn_off": "Desligar o temporizador",
   "sleep_episode_function_toggled_on": "O temporizador foi definido",
   "sleep_episode_function_toggled_off": "O temporizador está desligado",
+  "sleep_episode_function_end_of_episode": "No fim do episódio",
   "sleep_episode_function_5_minutes": "5 minutos",
   "sleep_episode_function_15_minutes": "15 minutos",
   "sleep_episode_function_30_minutes": "30 minutos",

--- a/lib/l10n/messages_de.dart
+++ b/lib/l10n/messages_de.dart
@@ -126,6 +126,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "settings_playback_divider_label": MessageLookupByLibrary.simpleMessage("WIEDERGABE"),
         "settings_theme_switch_label": MessageLookupByLibrary.simpleMessage("Dark theme"),
         "show_notes_label": MessageLookupByLibrary.simpleMessage("Notizen anzeigen"),
+        "sleep_episode_function_end_of_episode": MessageLookupByLibrary.simpleMessage("Ende von episode"),
         "sleep_episode_function_5_minutes" : MessageLookupByLibrary.simpleMessage("5 Minuten"),
         "sleep_episode_function_15_minutes" : MessageLookupByLibrary.simpleMessage("15 Minuten"),
         "sleep_episode_function_30_minutes" : MessageLookupByLibrary.simpleMessage("30 Minuten"),

--- a/lib/l10n/messages_en.dart
+++ b/lib/l10n/messages_en.dart
@@ -118,6 +118,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "settings_playback_divider_label": MessageLookupByLibrary.simpleMessage("PLAYBACK"),
         "settings_theme_switch_label": MessageLookupByLibrary.simpleMessage("Dark theme"),
         "show_notes_label": MessageLookupByLibrary.simpleMessage("Show notes"),
+        "sleep_episode_function_end_of_episode": MessageLookupByLibrary.simpleMessage("End of episode"),
         "sleep_episode_function_5_minutes": MessageLookupByLibrary.simpleMessage("5 minutes"),
         "sleep_episode_function_15_minutes" : MessageLookupByLibrary.simpleMessage("15 minutes"),
         "sleep_episode_function_30_minutes" : MessageLookupByLibrary.simpleMessage("30 minutes"),

--- a/lib/l10n/messages_messages.dart
+++ b/lib/l10n/messages_messages.dart
@@ -120,6 +120,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "settings_playback_divider_label": MessageLookupByLibrary.simpleMessage("PLAYBACK"),
         "settings_theme_switch_label": MessageLookupByLibrary.simpleMessage("Dark theme"),
         "show_notes_label": MessageLookupByLibrary.simpleMessage("Show notes"),
+        "sleep_episode_function_end_of_episode": MessageLookupByLibrary.simpleMessage("End of episode"),
         "stop_download_button_label": MessageLookupByLibrary.simpleMessage("Stop"),
         "stop_download_confirmation":
             MessageLookupByLibrary.simpleMessage("Are you sure you wish to stop this download and delete the episode?"),

--- a/lib/l10n/messages_pt.dart
+++ b/lib/l10n/messages_pt.dart
@@ -75,6 +75,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "settings_mark_deleted_played_label" : MessageLookupByLibrary.simpleMessage("Marcar os episódios deletados como já reproduzidos"),
     "settings_theme_switch_label" : MessageLookupByLibrary.simpleMessage("Tema escuro"),
     "show_notes_label" : MessageLookupByLibrary.simpleMessage("Mostrar notas"),
+    "sleep_episode_function_end_of_episode": MessageLookupByLibrary.simpleMessage("No fim do episódio"),
     "sleep_episode_function_5_minutes" : MessageLookupByLibrary.simpleMessage("5 minutos"),
     "sleep_episode_function_15_minutes" : MessageLookupByLibrary.simpleMessage("15 minutos"),
     "sleep_episode_function_30_minutes" : MessageLookupByLibrary.simpleMessage("30 minutos"),

--- a/lib/services/audio/audio_player_service.dart
+++ b/lib/services/audio/audio_player_service.dart
@@ -87,6 +87,7 @@ abstract class AudioPlayerService {
   /// Event listeners
   Stream<AudioState> playingState;
   Stream<PositionState> playPosition;
+  Stream<bool> episodeCompletedEvent;
   Stream<Episode> episodeEvent;
   Stream<int> playbackError;
   Stream<QueueListState> queueState;

--- a/lib/services/audio/default_audio_player_service.dart
+++ b/lib/services/audio/default_audio_player_service.dart
@@ -65,6 +65,9 @@ class DefaultAudioPlayerService extends AudioPlayerService {
   /// Stream for the last audio error as an integer code.
   final PublishSubject<int> _playbackError = PublishSubject<int>();
 
+  /// Stream for end of episode notification as an bool.
+  final PublishSubject<bool> _episodeCompletedEvent = PublishSubject<bool>();
+
   final BehaviorSubject<QueueListState> _queueState = BehaviorSubject<QueueListState>();
 
   DefaultAudioPlayerService({
@@ -466,6 +469,7 @@ class DefaultAudioPlayerService extends AudioPlayerService {
 
       _updateQueueState();
     }
+    _episodeCompletedEvent.add(true);
   }
 
   void _onLoadEpisode(PlaybackState state) async {
@@ -606,6 +610,9 @@ class DefaultAudioPlayerService extends AudioPlayerService {
 
   @override
   Stream<QueueListState> get queueState => _queueState.stream;
+
+  @override
+  Stream<bool> get episodeCompletedEvent => _episodeCompletedEvent.stream;
 }
 
 /// This is the default audio handler used by the [DefaultAudioPlayerService] service.

--- a/lib/state/sleep_policy.dart
+++ b/lib/state/sleep_policy.dart
@@ -46,6 +46,23 @@ class SleepPolicyTimer extends SleepPolicy {
   }
 }
 
+class SleepPolicyEndOfEpisode extends SleepPolicy {
+  SleepPolicyEndOfEpisode(
+      bool feedbackGiven,
+      ) : super(feedbackGiven);
+
+  @override
+  bool operator ==(Object other) {
+    return other is SleepPolicyEndOfEpisode;
+  }
+
+  @override
+  int get hashCode => feedbackGiven.hashCode;
+}
+
+SleepPolicy sleepPolicyEndOfEpisode([bool feedbackGiven = false]) =>
+    SleepPolicyEndOfEpisode(feedbackGiven);
+
 SleepPolicy sleepPolicyOff([bool feedbackGiven = false]) =>
     SleepPolicyOff(feedbackGiven);
 

--- a/lib/ui/widgets/sleep_selector.dart
+++ b/lib/ui/widgets/sleep_selector.dart
@@ -134,6 +134,10 @@ class SleepSelector extends StatelessWidget {
           texts.sleep_episode_function_60_minutes,
           sleepPolicyMinutes(60),
         ),
+        SleepOption(
+          texts.sleep_episode_function_end_of_episode,
+          sleepPolicyEndOfEpisode(),
+        ),
       ],
     );
     return options;


### PR DESCRIPTION
This PR introduces "End of episode" sleep policy. 

The need for this sleep policy arose after updating anytime to get Queue feature. When enabled, the player will be stopped after moving up the next item on queue.