### PR TITLE
Up Next bottom sheet placement

### DIFF
--- a/lib/ui/podcast/now_playing.dart
+++ b/lib/ui/podcast/now_playing.dart
@@ -89,6 +89,7 @@ class _NowPlayingState extends State<NowPlaying> with WidgetsBindingObserver {
     final audioBloc = Provider.of<AudioBloc>(context, listen: false);
     final playerBuilder = PlayerControlsBuilder.of(context);
     final isLight = Theme.of(context).brightness == Brightness.light;
+    final double bottomPadding = MediaQuery.of(context).viewPadding.bottom;
 
     return StreamBuilder<Episode>(
         stream: audioBloc.nowPlaying,
@@ -171,7 +172,7 @@ class _NowPlayingState extends State<NowPlaying> with WidgetsBindingObserver {
                     )),
                 if (scrollPos > 0)
                   Padding(
-                    padding: isEmbedded ? EdgeInsets.only(bottom: 64) : EdgeInsets.zero,
+                    padding: isEmbedded ? EdgeInsets.only(bottom: bottomPadding + 64) : EdgeInsets.zero,
                     child: Opacity(
                       opacity: opacity,
                       child: Column(
@@ -191,7 +192,7 @@ class _NowPlayingState extends State<NowPlaying> with WidgetsBindingObserver {
                   builder: (context, snapshot) {
                     if (snapshot.hasData) {
                       return Padding(
-                        padding: isEmbedded ? EdgeInsets.only(bottom: 64) : EdgeInsets.zero,
+                        padding: isEmbedded ? EdgeInsets.only(bottom: bottomPadding + 64) : EdgeInsets.zero,
                         child: NowPlayingOptionsSelector(scrollPos: scrollPos, baseSize: baseSize, isEmbedded: isEmbedded),
                       );
                     }
@@ -207,11 +208,13 @@ class _NowPlayingState extends State<NowPlaying> with WidgetsBindingObserver {
   void _policyChanged(SleepPolicy policy) {
     final scaffoldMessenger = ScaffoldMessenger.of(context);
     final texts = L.of(context);
+    final double bottomPadding = MediaQuery.of(context).viewPadding.bottom;
+
     if (scaffoldMessenger != null) {
       scaffoldMessenger.showSnackBar(
         SnackBar(
           behavior: SnackBarBehavior.floating,
-          margin: EdgeInsets.only(bottom: baseSize + (isEmbedded ? 64.0 : 4.0)),
+          margin: EdgeInsets.only(bottom: baseSize + (isEmbedded ? bottomPadding + 64.0 : 4.0)),
           content: Text(
             policy is SleepPolicyOff ? texts.sleep_episode_function_toggled_off : texts.sleep_episode_function_toggled_on,
           ),


### PR DESCRIPTION
This PR addresses Up Next bottom sheet placement issue.

Here's a screenshot of Up Next bottom sheet placement issue encountered on iPhone 12 Pro device:
<img src="https://user-images.githubusercontent.com/4012752/184963903-85912fa7-b4be-4a88-a1cc-1453555745f1.png" data-canonical-src="https://user-images.githubusercontent.com/4012752/184963903-85912fa7-b4be-4a88-a1cc-1453555745f1.png" width="360" alt="Screenshot of Up Next bottom sheet placement issue encountered on iPhone 12 Pro" title="Screenshot of Up Next bottom sheet placement issue encountered on iPhone 12 Pro"/>

### Changes:
- bottomPadding of view is added into consideration when placing Up Next bottom sheet and snackbar notifications