### PR TITLE
Update dependencies and deprecated theme values

### DIFF
--- a/ios/Podfile
+++ b/ios/Podfile
@@ -1,5 +1,5 @@
 # Uncomment this line to define a global platform for your project
-platform :ios, '9.0'
+platform :ios, '11.0'
 
 # CocoaPods analytics sends network stats synchronously affecting flutter build latency.
 ENV['COCOAPODS_DISABLE_STATS'] = 'true'

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 51;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -225,6 +225,7 @@
 		};
 		3B06AD1E1E4923F5004D2608 /* Thin Binary */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);
@@ -239,6 +240,7 @@
 		};
 		9740EEB61CF901F6004384FC /* Run Script */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -75,5 +75,7 @@
       </array>
 	<key>CADisableMinimumFrameDurationOnPhone</key>
 	<true/>
+	<key>UIApplicationSupportsIndirectInputEvents</key>
+	<true/>
 </dict>
 </plist>

--- a/lib/services/podcast/mobile_opml_service.dart
+++ b/lib/services/podcast/mobile_opml_service.dart
@@ -103,14 +103,13 @@ class MobileOPMLService extends OPMLService {
     final export = builder.buildDocument();
 
     var output = Platform.isAndroid ? await getExternalStorageDirectory() : await getApplicationDocumentsDirectory();
-    var outputFile = '${output.path}/anytime_export.opml';
-    var file = File(outputFile);
+    var outputFilePath = '${output.path}/anytime_export.opml';
+    var file = File(outputFilePath);
 
     file.writeAsStringSync(export.toXmlString(pretty: true));
-
-    await Share.shareFiles(
+    final outputFile = XFile(file.path);
+    await Share.shareXFiles(
       [outputFile],
-      mimeTypes: ['text/xml', 'application/xml'],
       subject: 'Anytime OPML',
     );
 

--- a/lib/state/sleep_policy.dart
+++ b/lib/state/sleep_policy.dart
@@ -1,5 +1,3 @@
-import 'dart:ui';
-
 abstract class SleepPolicy {
   bool feedbackGiven;
 
@@ -34,11 +32,13 @@ class SleepPolicyTimer extends SleepPolicy {
 
   @override
   bool operator ==(Object other) {
-    return other is SleepPolicyTimer && other.duration == duration && other._millisecond == _millisecond;
+    return other is SleepPolicyTimer &&
+        other.duration == duration &&
+        other._millisecond == _millisecond;
   }
 
   @override
-  int get hashCode => hashValues(duration.hashCode, _millisecond.hashCode);
+  int get hashCode => Object.hash(duration.hashCode, _millisecond.hashCode);
 
   @override
   String toString() {
@@ -48,8 +48,8 @@ class SleepPolicyTimer extends SleepPolicy {
 
 class SleepPolicyEndOfEpisode extends SleepPolicy {
   SleepPolicyEndOfEpisode(
-      bool feedbackGiven,
-      ) : super(feedbackGiven);
+    bool feedbackGiven,
+  ) : super(feedbackGiven);
 
   @override
   bool operator ==(Object other) {
@@ -67,7 +67,7 @@ SleepPolicy sleepPolicyOff([bool feedbackGiven = false]) =>
     SleepPolicyOff(feedbackGiven);
 
 SleepPolicy sleepPolicyMinutes(int minutes) => SleepPolicyTimer(
-  Duration(minutes: minutes),
-  DateTime.now().millisecondsSinceEpoch,
-  false,
-);
+      Duration(minutes: minutes),
+      DateTime.now().millisecondsSinceEpoch,
+      false,
+    );

--- a/lib/ui/anytime_podcast_app.dart
+++ b/lib/ui/anytime_podcast_app.dart
@@ -105,7 +105,8 @@ class AnytimePodcastApp extends StatefulWidget {
   AnytimePodcastAppState createState() => AnytimePodcastAppState();
 }
 
-class AnytimePodcastAppState extends State<AnytimePodcastApp> with WidgetsBindingObserver {
+class AnytimePodcastAppState extends State<AnytimePodcastApp>
+    with WidgetsBindingObserver {
   ThemeData theme;
   AudioBloc audioBloc;
 
@@ -121,7 +122,9 @@ class AnytimePodcastAppState extends State<AnytimePodcastApp> with WidgetsBindin
 
     widget.settingsBloc.settings.listen((event) {
       setState(() {
-        var newTheme = event.theme == 'dark' ? Themes.darkTheme().themeData : Themes.lightTheme().themeData;
+        var newTheme = event.theme == 'dark'
+            ? Themes.darkTheme().themeData
+            : Themes.lightTheme().themeData;
 
         /// Only update the theme if it has changed.
         if (newTheme != theme) {
@@ -214,7 +217,8 @@ class AnytimePodcastAppState extends State<AnytimePodcastApp> with WidgetsBindin
           dispose: (_, value) => value.dispose(),
         ),
         Provider<AudioBloc>(
-          create: (_) => AudioBloc(audioPlayerService: widget.audioPlayerService),
+          create: (_) =>
+              AudioBloc(audioPlayerService: widget.audioPlayerService),
           dispose: (_, value) => value.dispose(),
         ),
         Provider<SettingsBloc>(
@@ -257,13 +261,18 @@ class AnytimeHomePage extends StatefulWidget {
   final bool topBarVisible;
   final bool inlineSearch;
 
-  AnytimeHomePage({this.title, this.noSubscriptionsMessage, this.topBarVisible = true, this.inlineSearch = false});
+  AnytimeHomePage(
+      {this.title,
+      this.noSubscriptionsMessage,
+      this.topBarVisible = true,
+      this.inlineSearch = false});
 
   @override
   State<AnytimeHomePage> createState() => _AnytimeHomePageState();
 }
 
-class _AnytimeHomePageState extends State<AnytimeHomePage> with WidgetsBindingObserver {
+class _AnytimeHomePageState extends State<AnytimeHomePage>
+    with WidgetsBindingObserver {
   StreamSubscription deepLinkSubscription;
   final log = Logger('_AnytimeHomePageState');
   bool handledInitialLink = false;
@@ -326,7 +335,9 @@ class _AnytimeHomePageState extends State<AnytimeHomePage> with WidgetsBindingOb
         Navigator.of(context).popUntil((route) {
           var currentRouteName = NavigationRouteObserver().top.settings.name;
 
-          return currentRouteName == null || currentRouteName == '' || currentRouteName == '/';
+          return currentRouteName == null ||
+              currentRouteName == '' ||
+              currentRouteName == '/';
         });
 
         /// Once we have reached the root route, push podcast details.
@@ -335,7 +346,8 @@ class _AnytimeHomePageState extends State<AnytimeHomePage> with WidgetsBindingOb
           MaterialPageRoute<void>(
               fullscreenDialog: true,
               settings: RouteSettings(name: 'podcastdetails'),
-              builder: (context) => PodcastDetails(Podcast.fromUrl(url: path), loadPodcastBloc)),
+              builder: (context) =>
+                  PodcastDetails(Podcast.fromUrl(url: path), loadPodcastBloc)),
         );
       }
     }
@@ -378,7 +390,7 @@ class _AnytimeHomePageState extends State<AnytimeHomePage> with WidgetsBindingOb
     return AnnotatedRegion<SystemUiOverlayStyle>(
       value: SystemUiOverlayStyle(
         statusBarIconBrightness: isLight ? Brightness.dark : Brightness.light,
-        systemNavigationBarColor: Theme.of(context).bottomAppBarColor,
+        systemNavigationBarColor: Theme.of(context).bottomAppBarTheme.color,
         statusBarColor: Colors.transparent,
       ),
       child: Scaffold(
@@ -419,13 +431,15 @@ class _AnytimeHomePageState extends State<AnytimeHomePage> with WidgetsBindingOb
                           itemBuilder: (BuildContext context) {
                             return <PopupMenuEntry<String>>[
                               PopupMenuItem<String>(
-                                textStyle: Theme.of(context).textTheme.subtitle1,
+                                textStyle:
+                                    Theme.of(context).textTheme.titleMedium,
                                 value: 'layout',
                                 child: Row(
                                   crossAxisAlignment: CrossAxisAlignment.center,
                                   children: [
                                     Padding(
-                                      padding: const EdgeInsets.only(right: 8.0),
+                                      padding:
+                                          const EdgeInsets.only(right: 8.0),
                                       child: Icon(Icons.dashboard, size: 18.0),
                                     ),
                                     Text(L.of(context).layout_label),
@@ -433,13 +447,15 @@ class _AnytimeHomePageState extends State<AnytimeHomePage> with WidgetsBindingOb
                                 ),
                               ),
                               PopupMenuItem<String>(
-                                textStyle: Theme.of(context).textTheme.subtitle1,
+                                textStyle:
+                                    Theme.of(context).textTheme.titleMedium,
                                 value: 'rss',
                                 child: Row(
                                   crossAxisAlignment: CrossAxisAlignment.center,
                                   children: [
                                     Padding(
-                                      padding: const EdgeInsets.only(right: 8.0),
+                                      padding:
+                                          const EdgeInsets.only(right: 8.0),
                                       child: Icon(Icons.rss_feed, size: 18.0),
                                     ),
                                     Text(L.of(context).add_rss_feed_option),
@@ -447,12 +463,14 @@ class _AnytimeHomePageState extends State<AnytimeHomePage> with WidgetsBindingOb
                                 ),
                               ),
                               PopupMenuItem<String>(
-                                textStyle: Theme.of(context).textTheme.subtitle1,
+                                textStyle:
+                                    Theme.of(context).textTheme.titleMedium,
                                 value: 'settings',
                                 child: Row(
                                   children: [
                                     Padding(
-                                      padding: const EdgeInsets.only(right: 8.0),
+                                      padding:
+                                          const EdgeInsets.only(right: 8.0),
                                       child: Icon(Icons.settings, size: 18.0),
                                     ),
                                     Text(L.of(context).settings_label),
@@ -460,13 +478,16 @@ class _AnytimeHomePageState extends State<AnytimeHomePage> with WidgetsBindingOb
                                 ),
                               ),
                               PopupMenuItem<String>(
-                                textStyle: Theme.of(context).textTheme.subtitle1,
+                                textStyle:
+                                    Theme.of(context).textTheme.titleMedium,
                                 value: 'about',
                                 child: Row(
                                   children: [
                                     Padding(
-                                      padding: const EdgeInsets.only(right: 8.0),
-                                      child: Icon(Icons.info_outline, size: 18.0),
+                                      padding:
+                                          const EdgeInsets.only(right: 8.0),
+                                      child:
+                                          Icon(Icons.info_outline, size: 18.0),
                                     ),
                                     Text(L.of(context).about_label),
                                   ],
@@ -480,8 +501,10 @@ class _AnytimeHomePageState extends State<AnytimeHomePage> with WidgetsBindingOb
                   ),
                   StreamBuilder<int>(
                       stream: pager.currentPage,
-                      builder: (BuildContext context, AsyncSnapshot<int> snapshot) {
-                        return _fragment(snapshot.data, settings.searchProvider);
+                      builder:
+                          (BuildContext context, AsyncSnapshot<int> snapshot) {
+                        return _fragment(
+                            snapshot.data, settings.searchProvider);
                       }),
                 ],
               ),
@@ -495,19 +518,25 @@ class _AnytimeHomePageState extends State<AnytimeHomePage> with WidgetsBindingOb
               stream: pager.currentPage,
               initialData: 0,
               builder: (BuildContext context, AsyncSnapshot<int> snapshot) {
-
                 var selectedItemColor = Theme.of(context).iconTheme.color;
-                var unselectedItemColor = HSLColor.fromColor(Theme.of(context).bottomAppBarColor).withLightness(0.85).toColor();
+                var unselectedItemColor = HSLColor.fromColor(
+                        Theme.of(context).bottomAppBarTheme.color)
+                    .withLightness(0.85)
+                    .toColor();
                 return BottomNavigationBar(
                   elevation: Theme.of(context).bottomAppBarTheme.elevation,
                   type: BottomNavigationBarType.fixed,
-                  backgroundColor: Theme.of(context).bottomAppBarColor,
+                  backgroundColor: Theme.of(context).bottomAppBarTheme.color,
                   selectedIconTheme: Theme.of(context).iconTheme,
                   selectedItemColor: Theme.of(context).iconTheme.color,
-                  unselectedItemColor: HSLColor.fromColor(Theme.of(context).bottomAppBarColor).withLightness(0.85).toColor(),
+                  unselectedItemColor: HSLColor.fromColor(
+                          Theme.of(context).bottomAppBarTheme.color)
+                      .withLightness(0.85)
+                      .toColor(),
                   currentIndex: snapshot.data,
                   onTap: pager.changePage,
-                  items: _buildNavBarItems(unselectedItemColor, selectedItemColor, context, settings),
+                  items: _buildNavBarItems(unselectedItemColor,
+                      selectedItemColor, context, settings),
                 );
               }),
         ),
@@ -527,22 +556,52 @@ class _AnytimeHomePageState extends State<AnytimeHomePage> with WidgetsBindingOb
     }
   }
 
-  List<BottomNavigationBarItem> _buildNavBarItems(
-      Color unselectedItemColor, Color selectedItemColor, BuildContext context, AppSettings settings) {
+  List<BottomNavigationBarItem> _buildNavBarItems(Color unselectedItemColor,
+      Color selectedItemColor, BuildContext context, AppSettings settings) {
     var navBarItems = <BottomNavigationBarItem>[
       BottomNavigationBarItem(
-        icon: SvgPicture.asset('assets/icons/library.svg', color: unselectedItemColor, height: 24, width: 24),
-        activeIcon: SvgPicture.asset('assets/icons/library.svg', color: selectedItemColor, height: 32, width: 32),
+        icon: SvgPicture.asset(
+          'assets/icons/library.svg',
+          colorFilter: ColorFilter.mode(unselectedItemColor, BlendMode.srcATop),
+          height: 24,
+          width: 24,
+        ),
+        activeIcon: SvgPicture.asset(
+          'assets/icons/library.svg',
+          colorFilter: ColorFilter.mode(selectedItemColor, BlendMode.srcATop),
+          height: 32,
+          width: 32,
+        ),
         label: L.of(context).library,
       ),
       BottomNavigationBarItem(
-        icon: SvgPicture.asset('assets/icons/discovery.svg', color: unselectedItemColor, height: 24, width: 24),
-        activeIcon: SvgPicture.asset('assets/icons/discovery.svg', color: selectedItemColor, height: 32, width: 32),
+        icon: SvgPicture.asset(
+          'assets/icons/discovery.svg',
+          colorFilter: ColorFilter.mode(unselectedItemColor, BlendMode.srcATop),
+          height: 24,
+          width: 24,
+        ),
+        activeIcon: SvgPicture.asset(
+          'assets/icons/discovery.svg',
+          colorFilter: ColorFilter.mode(selectedItemColor, BlendMode.srcATop),
+          height: 32,
+          width: 32,
+        ),
         label: L.of(context).discover,
       ),
       BottomNavigationBarItem(
-        icon: SvgPicture.asset('assets/icons/download.svg', color: unselectedItemColor, height: 24, width: 24),
-        activeIcon: SvgPicture.asset('assets/icons/download.svg', color: selectedItemColor, height: 32, width: 32),
+        icon: SvgPicture.asset(
+          'assets/icons/download.svg',
+          colorFilter: ColorFilter.mode(unselectedItemColor, BlendMode.srcATop),
+          height: 24,
+          width: 24,
+        ),
+        activeIcon: SvgPicture.asset(
+          'assets/icons/download.svg',
+          colorFilter: ColorFilter.mode(selectedItemColor, BlendMode.srcATop),
+          height: 32,
+          width: 32,
+        ),
         label: L.of(context).downloads,
       ),
     ];
@@ -550,8 +609,20 @@ class _AnytimeHomePageState extends State<AnytimeHomePage> with WidgetsBindingOb
       navBarItems.insert(
           2,
           BottomNavigationBarItem(
-            icon: SvgPicture.asset('assets/icons/new_podcasts.svg', color: unselectedItemColor, height: 24, width: 24),
-            activeIcon: SvgPicture.asset('assets/icons/new_podcasts.svg', color: selectedItemColor, height: 32, width: 32),
+            icon: SvgPicture.asset(
+              'assets/icons/new_podcasts.svg',
+              colorFilter:
+                  ColorFilter.mode(unselectedItemColor, BlendMode.srcATop),
+              height: 24,
+              width: 24,
+            ),
+            activeIcon: SvgPicture.asset(
+              'assets/icons/new_podcasts.svg',
+              colorFilter:
+                  ColorFilter.mode(selectedItemColor, BlendMode.srcATop),
+              height: 32,
+              width: 32,
+            ),
             label: L.of(context).new_podcasts,
           ));
     }
@@ -646,7 +717,8 @@ class _AnytimeHomePageState extends State<AnytimeHomePage> with WidgetsBindingOb
                     context,
                     MaterialPageRoute<void>(
                         settings: RouteSettings(name: 'podcastdetails'),
-                        builder: (context) => PodcastDetails(Podcast.fromUrl(url: url), podcastBloc)),
+                        builder: (context) => PodcastDetails(
+                            Podcast.fromUrl(url: url), podcastBloc)),
                   ).then((value) => Navigator.pop(context));
                 },
               ),
@@ -669,21 +741,21 @@ class _AnytimeHomePageState extends State<AnytimeHomePage> with WidgetsBindingOb
 }
 
 class TitleWidget extends StatelessWidget {
-  final TextStyle _titleTheme1 = theme.textTheme.bodyText2.copyWith(
+  final TextStyle _titleTheme1 = theme.textTheme.bodyMedium.copyWith(
     color: Colors.red,
     fontWeight: FontWeight.bold,
     fontFamily: 'MontserratRegular',
     fontSize: 18,
   );
 
-  final TextStyle _titleTheme2Light = theme.textTheme.bodyText2.copyWith(
+  final TextStyle _titleTheme2Light = theme.textTheme.bodyMedium.copyWith(
     color: Colors.black,
     fontWeight: FontWeight.bold,
     fontFamily: 'MontserratRegular',
     fontSize: 18,
   );
 
-  final TextStyle _titleTheme2Dark = theme.textTheme.bodyText2.copyWith(
+  final TextStyle _titleTheme2Dark = theme.textTheme.bodyMedium.copyWith(
     color: Colors.white,
     fontWeight: FontWeight.bold,
     fontFamily: 'MontserratRegular',
@@ -702,7 +774,9 @@ class TitleWidget extends StatelessWidget {
           ),
           Text(
             'Player',
-            style: Theme.of(context).brightness == Brightness.light ? _titleTheme2Light : _titleTheme2Dark,
+            style: Theme.of(context).brightness == Brightness.light
+                ? _titleTheme2Light
+                : _titleTheme2Dark,
           ),
         ],
       ),

--- a/lib/ui/library/discovery_results.dart
+++ b/lib/ui/library/discovery_results.dart
@@ -58,7 +58,7 @@ class DiscoveryResults extends StatelessWidget {
                     ),
                     Text(
                       L.of(context).no_search_results_message,
-                      style: Theme.of(context).textTheme.headline6,
+                      style: Theme.of(context).textTheme.titleLarge,
                       textAlign: TextAlign.center,
                     ),
                   ],

--- a/lib/ui/library/downloads.dart
+++ b/lib/ui/library/downloads.dart
@@ -119,7 +119,7 @@ class _DownloadsState extends State<Downloads> {
               ),
               Text(
                 L.of(context).no_downloads_message,
-                style: Theme.of(context).textTheme.headline6,
+                style: Theme.of(context).textTheme.titleLarge,
                 textAlign: TextAlign.center,
               ),
             ],

--- a/lib/ui/library/episodes.dart
+++ b/lib/ui/library/episodes.dart
@@ -122,7 +122,7 @@ class _EpisodesState extends State<Episodes> {
               ),
               Text(
                 L.of(context).no_downloads_message,
-                style: Theme.of(context).textTheme.headline6,
+                style: Theme.of(context).textTheme.titleLarge,
                 textAlign: TextAlign.center,
               ),
             ],

--- a/lib/ui/library/library.dart
+++ b/lib/ui/library/library.dart
@@ -48,7 +48,7 @@ class _LibraryState extends State<Library> {
                       ),
                       Text(
                         widget.noSubscriptionsMessage ?? L.of(context).no_subscriptions_message,
-                        style: Theme.of(context).textTheme.headline6,
+                        style: Theme.of(context).textTheme.titleLarge,
                         textAlign: TextAlign.center,
                       ),
                     ],

--- a/lib/ui/library/new_podcasts_results.dart
+++ b/lib/ui/library/new_podcasts_results.dart
@@ -55,7 +55,7 @@ class NewPodcastsResults extends StatelessWidget {
                     ),
                     Text(
                       L.of(context).no_search_results_message,
-                      style: Theme.of(context).textTheme.headline6,
+                      style: Theme.of(context).textTheme.titleLarge,
                       textAlign: TextAlign.center,
                     ),
                   ],

--- a/lib/ui/podcast/chapter_selector.dart
+++ b/lib/ui/podcast/chapter_selector.dart
@@ -87,7 +87,7 @@ class _ChapterSelectorState extends State<ChapterSelector> {
                     final index = i < 0 ? 0 : i;
                     final chapter = snapshot.data.chapters[index];
                     final chapterSelected = chapter == snapshot.data.currentChapter;
-                    final textStyle = Theme.of(context).textTheme.bodyText1.copyWith(
+                    final textStyle = Theme.of(context).textTheme.bodyLarge.copyWith(
                           fontSize: 14,
                           fontWeight: FontWeight.normal,
                           color: Theme.of(context).colorScheme.onSecondary,
@@ -98,7 +98,7 @@ class _ChapterSelectorState extends State<ChapterSelector> {
                     /// still visible behind the transport control. This is a little hack, but fixes
                     /// the issue until I can get ListTile to work correctly.
                     return Container(
-                      color: chapterSelected ? Theme.of(context).selectedRowColor : Colors.transparent,
+                      color: chapterSelected ? Theme.of(context).colorScheme.primary : Colors.transparent,
                       child: Padding(
                         padding: const EdgeInsets.fromLTRB(4.0, 0.0, 4.0, 0.0),
                         child: ListTile(

--- a/lib/ui/podcast/chapter_selector.dart
+++ b/lib/ui/podcast/chapter_selector.dart
@@ -90,7 +90,9 @@ class _ChapterSelectorState extends State<ChapterSelector> {
                     final textStyle = Theme.of(context).textTheme.bodyLarge.copyWith(
                           fontSize: 14,
                           fontWeight: FontWeight.normal,
-                          color: Theme.of(context).colorScheme.onSecondary,
+                          color: chapterSelected
+                              ? Theme.of(context).colorScheme.background
+                              : Theme.of(context).colorScheme.onSecondary,
                         );
 
                     /// We should be able to use the selectedTileColor property but, if we do, when

--- a/lib/ui/podcast/episode_details.dart
+++ b/lib/ui/podcast/episode_details.dart
@@ -68,7 +68,7 @@ class _EpisodeDetailsState extends State<EpisodeDetails> {
                       overflow: TextOverflow.ellipsis,
                       maxLines: 2,
                       softWrap: false,
-                      style: Theme.of(context).textTheme.bodyText2,
+                      style: Theme.of(context).textTheme.bodyMedium,
                     )),
                 Divider(),
                 Padding(

--- a/lib/ui/podcast/funding_menu.dart
+++ b/lib/ui/podcast/funding_menu.dart
@@ -78,9 +78,11 @@ class _MaterialFundingMenu extends StatelessWidget {
                 },
                 icon: Icon(
                   Icons.payment,
+                  color: Theme.of(context).primaryIconTheme.color,
                 ),
                 itemBuilder: (BuildContext context) {
-                  return List<PopupMenuEntry<String>>.generate(funding.length, (index) {
+                  return List<PopupMenuEntry<String>>.generate(funding.length,
+                      (index) {
                     return PopupMenuItem<String>(
                       value: funding[index].url,
                       enabled: true,
@@ -114,13 +116,17 @@ class _CupertinoFundingMenu extends StatelessWidget {
             initialData: AppSettings.sensibleDefaults(),
             builder: (context, snapshot) {
               return IconButton(
-                icon: Icon(Icons.payment),
+                icon: Icon(
+                  Icons.payment,
+                  color: Theme.of(context).primaryIconTheme.color,
+                ),
                 onPressed: () => showCupertinoModalPopup<void>(
                   context: context,
                   builder: (BuildContext context) {
                     return CupertinoActionSheet(
                       actions: <Widget>[
-                        ...List<CupertinoActionSheetAction>.generate(funding.length, (index) {
+                        ...List<CupertinoActionSheetAction>.generate(
+                            funding.length, (index) {
                           return CupertinoActionSheetAction(
                             onPressed: () {
                               FundingLink.fundingLink(
@@ -156,7 +162,8 @@ class FundingLink {
   /// requested to open a funding link, present the user with and
   /// information dialog first to make clear that the link is provided
   /// by the podcast owner and not AnyTime.
-  static Future<bool> fundingLink(String url, bool consent, BuildContext context) async {
+  static Future<bool> fundingLink(
+      String url, bool consent, BuildContext context) async {
     var result = false;
 
     if (consent) {

--- a/lib/ui/podcast/mini_player.dart
+++ b/lib/ui/podcast/mini_player.dart
@@ -76,7 +76,7 @@ class _MiniPlayerBuilderState extends State<_MiniPlayerBuilder> with SingleTicke
       },
       direction: DismissDirection.startToEnd,
       background: Container(
-        color: Theme.of(context).backgroundColor,
+        color: Theme.of(context).colorScheme.background,
         height: 64.0,
       ),
       child: GestureDetector(
@@ -98,7 +98,7 @@ class _MiniPlayerBuilderState extends State<_MiniPlayerBuilder> with SingleTicke
         child: Container(
           height: 60,
           decoration: BoxDecoration(
-              color: Theme.of(context).backgroundColor,
+              color: Theme.of(context).colorScheme.background,
               border: Border(
                 top: Divider.createBorderSide(context, width: 0.5, color: Theme.of(context).dividerColor),
                 bottom: Divider.createBorderSide(context, width: 0.5, color: Theme.of(context).dividerColor),
@@ -144,7 +144,7 @@ class _MiniPlayerBuilderState extends State<_MiniPlayerBuilder> with SingleTicke
                                 Text(
                                   snapshot.data?.title ?? '',
                                   overflow: TextOverflow.ellipsis,
-                                  style: textTheme.bodyText1.copyWith(
+                                  style: textTheme.bodyLarge.copyWith(
                                     height: 1.22,
                                     fontSize: 14,
                                     color: Theme.of(context).colorScheme.onSecondary,
@@ -155,7 +155,7 @@ class _MiniPlayerBuilderState extends State<_MiniPlayerBuilder> with SingleTicke
                                   child: Text(
                                     snapshot.data?.author ?? '',
                                     overflow: TextOverflow.ellipsis,
-                                    style: textTheme.subtitle1.copyWith(
+                                    style: textTheme.titleMedium.copyWith(
                                       letterSpacing: 0.25,
                                       height: 1.22,
                                       fontSize: 12.3,
@@ -179,7 +179,7 @@ class _MiniPlayerBuilderState extends State<_MiniPlayerBuilder> with SingleTicke
                                     padding: const EdgeInsets.symmetric(horizontal: 0.0),
                                     backgroundColor: Theme.of(context).brightness == Brightness.light
                                         ? Theme.of(context).buttonTheme.colorScheme.onPrimary
-                                        : Theme.of(context).bottomAppBarColor,
+                                        : Theme.of(context).bottomAppBarTheme.color,
                                     shape: CircleBorder(),
                                   ),
                                   onPressed: () {

--- a/lib/ui/podcast/now_playing.dart
+++ b/lib/ui/podcast/now_playing.dart
@@ -21,7 +21,6 @@ import 'package:anytime/ui/widgets/placeholder_builder.dart';
 import 'package:anytime/ui/widgets/podcast_html.dart';
 import 'package:anytime/ui/widgets/podcast_image.dart';
 import 'package:auto_size_text/auto_size_text.dart';
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:provider/provider.dart';
@@ -122,7 +121,7 @@ class _NowPlayingState extends State<NowPlaying> with WidgetsBindingObserver {
                       appBar: AppBar(
                         systemOverlayStyle: SystemUiOverlayStyle(
                           statusBarIconBrightness: isLight ? Brightness.dark : Brightness.light,
-                          systemNavigationBarColor: Theme.of(context).bottomAppBarColor,
+                          systemNavigationBarColor: Theme.of(context).bottomAppBarTheme.color,
                           statusBarColor: Colors.transparent,
                         ),
                         backgroundColor: Theme.of(context).scaffoldBackgroundColor,

--- a/lib/ui/podcast/now_playing_floating_player.dart
+++ b/lib/ui/podcast/now_playing_floating_player.dart
@@ -110,14 +110,14 @@ class _FloatingPlayerBuilderState extends State<_FloatingPlayerBuilder> with Sin
                           Text(
                             snapshot.data?.title ?? '',
                             overflow: TextOverflow.ellipsis,
-                            style: textTheme.bodyText2,
+                            style: textTheme.bodyMedium,
                           ),
                           Padding(
                             padding: const EdgeInsets.only(top: 4.0),
                             child: Text(
                               snapshot.data?.author ?? '',
                               overflow: TextOverflow.ellipsis,
-                              style: textTheme.caption,
+                              style: textTheme.bodySmall,
                             ),
                           ),
                         ],
@@ -134,10 +134,10 @@ class _FloatingPlayerBuilderState extends State<_FloatingPlayerBuilder> with Sin
                           return TextButton(
                             style: TextButton.styleFrom(
                               padding: const EdgeInsets.symmetric(horizontal: 0.0),
-                              shape: CircleBorder(side: BorderSide(color: Theme.of(context).backgroundColor, width: 0.0)),
+                              shape: CircleBorder(side: BorderSide(color: Theme.of(context).colorScheme.background, width: 0.0)),
                               backgroundColor: Theme.of(context).brightness == Brightness.light
                                   ? Theme.of(context).buttonTheme.colorScheme.onPrimary
-                                  : Theme.of(context).bottomAppBarColor,
+                                  : Theme.of(context).bottomAppBarTheme.color,
                             ),
                             onPressed: () {
                               if (playing) {

--- a/lib/ui/podcast/now_playing_options.dart
+++ b/lib/ui/podcast/now_playing_options.dart
@@ -40,7 +40,7 @@ class _NowPlayingOptionsSelectorState extends State<NowPlayingOptionsSelector> {
     final maxSize = (windowHeight - topMargin - (floatingPlayerHeight - widget.baseSize)) / windowHeight;
     final l10n = L.of(context);
 
-    final ColorTween sheetColor = ColorTween(begin: theme.scaffoldBackgroundColor, end: theme.bottomAppBarColor);
+    final ColorTween sheetColor = ColorTween(begin: theme.scaffoldBackgroundColor, end: theme.bottomAppBarTheme.color);
 
     final ColorTween labelColor = ColorTween(
       begin: theme.primaryIconTheme.color,
@@ -63,7 +63,7 @@ class _NowPlayingOptionsSelectorState extends State<NowPlayingOptionsSelector> {
               decoration: ShapeDecoration(
                 shape: RoundedRectangleBorder(
                   side: BorderSide(
-                    color: widget.isEmbedded ? theme.backgroundColor : theme.highlightColor,
+                    color: widget.isEmbedded ? theme.colorScheme.background : theme.highlightColor,
                     width: widget.isEmbedded ? 1.5 : 1.0,
                   ),
                   borderRadius: BorderRadius.only(
@@ -94,9 +94,9 @@ class _NowPlayingOptionsSelectorState extends State<NowPlayingOptionsSelector> {
                           padding: widget.isEmbedded ? EdgeInsets.zero : EdgeInsets.only(bottom: 8.0),
                           child: Text(
                             l10n.up_next_queue_label.toUpperCase(),
-                            style: textTheme.button.copyWith(
+                            style: textTheme.labelLarge.copyWith(
                               color: labelColor.animate(AlwaysStoppedAnimation(widget.scrollPos)).value,
-                              fontSize: widget.isEmbedded ? 9 : textTheme.button.fontSize,
+                              fontSize: widget.isEmbedded ? 9 : textTheme.labelLarge.fontSize,
                             ),
                           ),
                         ),
@@ -110,7 +110,7 @@ class _NowPlayingOptionsSelectorState extends State<NowPlayingOptionsSelector> {
                         padding: const EdgeInsets.fromLTRB(16.0, 8.0, 24.0, 8.0),
                         child: Text(
                           l10n.now_playing_queue_label,
-                          style: textTheme.headline6.copyWith(color: theme.iconTheme.color),
+                          style: textTheme.titleLarge.copyWith(color: theme.iconTheme.color),
                         ),
                       ),
                     ],
@@ -137,7 +137,7 @@ class _NowPlayingOptionsSelectorState extends State<NowPlayingOptionsSelector> {
                         padding: const EdgeInsets.fromLTRB(16.0, 0.0, 24.0, 8.0),
                         child: Text(
                           l10n.up_next_queue_label,
-                          style: textTheme.headline6.copyWith(color: theme.iconTheme.color),
+                          style: textTheme.titleLarge.copyWith(color: theme.iconTheme.color),
                         ),
                       ),
                       Spacer(),
@@ -181,7 +181,7 @@ class _NowPlayingOptionsSelectorState extends State<NowPlayingOptionsSelector> {
                           },
                           child: Text(
                             l10n.clear_queue_button_label,
-                            style: textTheme.subtitle2.copyWith(fontSize: 12.0, color: theme.iconTheme.color),
+                            style: textTheme.titleSmall.copyWith(fontSize: 12.0, color: theme.iconTheme.color),
                           ),
                         ),
                       ),
@@ -205,7 +205,7 @@ class _NowPlayingOptionsSelectorState extends State<NowPlayingOptionsSelector> {
                                     padding: const EdgeInsets.all(24.0),
                                     child: Text(
                                       l10n.empty_queue_message,
-                                      style: textTheme.subtitle1.copyWith(color: theme.iconTheme.color),
+                                      style: textTheme.titleMedium.copyWith(color: theme.iconTheme.color),
                                     ),
                                   ),
                                 ),

--- a/lib/ui/podcast/player_transport_controls.dart
+++ b/lib/ui/podcast/player_transport_controls.dart
@@ -17,7 +17,8 @@ import 'package:provider/provider.dart';
 /// See [NowPlaying].
 class PlayerTransportControls extends StatefulWidget {
   @override
-  State<PlayerTransportControls> createState() => _PlayerTransportControlsState();
+  State<PlayerTransportControls> createState() =>
+      _PlayerTransportControlsState();
 }
 
 class _PlayerTransportControlsState extends State<PlayerTransportControls> {
@@ -38,7 +39,9 @@ class _PlayerTransportControlsState extends State<PlayerTransportControls> {
                 SleepSelector(),
                 IconButton(
                   onPressed: () {
-                    return snapshot.data == AudioState.buffering ? null : _rewind(audioBloc);
+                    return snapshot.data == AudioState.buffering
+                        ? null
+                        : _rewind(audioBloc);
                   },
                   tooltip: L.of(context).rewind_button_label,
                   padding: const EdgeInsets.all(0.0),
@@ -50,7 +53,9 @@ class _PlayerTransportControlsState extends State<PlayerTransportControls> {
                 AnimatedPlayButton(audioState: snapshot.data),
                 IconButton(
                   onPressed: () {
-                    return snapshot.data == AudioState.buffering ? null : _fastforward(audioBloc);
+                    return snapshot.data == AudioState.buffering
+                        ? null
+                        : _fastforward(audioBloc);
                   },
                   padding: const EdgeInsets.all(0.0),
                   icon: Icon(
@@ -100,7 +105,8 @@ void _onPause(AudioBloc audioBloc) {
   audioBloc.transitionState(TransitionState.pause);
 }
 
-class _AnimatedPlayButtonState extends State<AnimatedPlayButton> with SingleTickerProviderStateMixin {
+class _AnimatedPlayButtonState extends State<AnimatedPlayButton>
+    with SingleTickerProviderStateMixin {
   AnimationController _playPauseController;
   StreamSubscription<AudioState> _audioStateSubscription;
   bool init = true;
@@ -111,7 +117,8 @@ class _AnimatedPlayButtonState extends State<AnimatedPlayButton> with SingleTick
 
     final audioBloc = Provider.of<AudioBloc>(context, listen: false);
 
-    _playPauseController = AnimationController(vsync: this, duration: Duration(milliseconds: 300));
+    _playPauseController =
+        AnimationController(vsync: this, duration: Duration(milliseconds: 300));
 
     /// Seems a little hacky, but when we load the form we want the play/pause
     /// button to be in the correct state. If we are building the first frame,
@@ -149,7 +156,8 @@ class _AnimatedPlayButtonState extends State<AnimatedPlayButton> with SingleTick
     final audioBloc = Provider.of<AudioBloc>(context, listen: false);
 
     final playing = widget.audioState == AudioState.playing;
-    final buffering = widget.audioState == null || widget.audioState == AudioState.buffering;
+    final buffering =
+        widget.audioState == null || widget.audioState == AudioState.buffering;
 
     return Stack(
       alignment: AlignmentDirectional.center,
@@ -166,12 +174,20 @@ class _AnimatedPlayButtonState extends State<AnimatedPlayButton> with SingleTick
             width: 84,
           ),
         Tooltip(
-          message: playing ? L.of(context).pause_button_label : L.of(context).play_button_label,
+          message: playing
+              ? L.of(context).pause_button_label
+              : L.of(context).play_button_label,
           child: TextButton(
             style: TextButton.styleFrom(
-              shape: CircleBorder(side: BorderSide(color: Theme.of(context).highlightColor, width: 0.0)),
-              backgroundColor: Theme.of(context).brightness == Brightness.light ? Colors.orange : Colors.grey[800],
-              primary: Theme.of(context).brightness == Brightness.light ? Colors.orange : Colors.grey[800],
+              foregroundColor: Theme.of(context).brightness == Brightness.light
+                  ? Colors.orange
+                  : Colors.grey[800],
+              shape: CircleBorder(
+                  side: BorderSide(
+                      color: Theme.of(context).highlightColor, width: 0.0)),
+              backgroundColor: Theme.of(context).brightness == Brightness.light
+                  ? Colors.orange
+                  : Colors.grey[800],
               padding: const EdgeInsets.all(6.0),
             ),
             onPressed: () {
@@ -186,7 +202,9 @@ class _AnimatedPlayButtonState extends State<AnimatedPlayButton> with SingleTick
             child: AnimatedIcon(
               size: 60.0,
               icon: AnimatedIcons.play_pause,
-              color: Theme.of(context).primaryColor == Colors.white ? Theme.of(context).scaffoldBackgroundColor : Colors.white,
+              color: Theme.of(context).primaryColor == Colors.white
+                  ? Theme.of(context).scaffoldBackgroundColor
+                  : Colors.white,
               progress: _playPauseController,
             ),
           ),

--- a/lib/ui/podcast/podcast_context_menu.dart
+++ b/lib/ui/podcast/podcast_context_menu.dart
@@ -57,6 +57,7 @@ class _MaterialPodcastMenu extends StatelessWidget {
             },
             icon: Icon(
               Icons.more_vert,
+              color: Theme.of(context).primaryIconTheme.color,
             ),
             itemBuilder: (BuildContext context) {
               return <PopupMenuEntry<String>>[
@@ -103,7 +104,10 @@ class _CupertinoContextMenu extends StatelessWidget {
         stream: bloc.details,
         builder: (context, snapshot) {
           return IconButton(
-            icon: Icon(CupertinoIcons.ellipsis),
+            icon: Icon(
+              CupertinoIcons.ellipsis,
+              color: Theme.of(context).primaryIconTheme.color,
+            ),
             onPressed: () => showCupertinoModalPopup<void>(
               context: context,
               builder: (BuildContext context) {

--- a/lib/ui/podcast/podcast_details.dart
+++ b/lib/ui/podcast/podcast_details.dart
@@ -84,7 +84,9 @@ class _PodcastDetailsState extends State<PodcastDetails> {
       }
     });
 
-    widget._podcastBloc.backgroundLoading.where((event) => event is BlocPopulatedState<void>).listen((event) {
+    widget._podcastBloc.backgroundLoading
+        .where((event) => event is BlocPopulatedState<void>)
+        .listen((event) {
       if (mounted) {
         /// If we have not scrolled (save a few pixels) just refresh the episode list;
         /// otherwise prompt the user to prevent unexpected list jumping
@@ -97,7 +99,9 @@ class _PodcastDetailsState extends State<PodcastDetails> {
             action: SnackBarAction(
               label: L.of(context).new_episodes_view_now_label,
               onPressed: () {
-                _sliverScrollController.animateTo(100, duration: Duration(milliseconds: 500), curve: Curves.easeInOut);
+                _sliverScrollController.animateTo(100,
+                    duration: Duration(milliseconds: 500),
+                    curve: Curves.easeInOut);
                 widget._podcastBloc.podcastEvent(PodcastEvent.refresh);
               },
             ),
@@ -111,8 +115,13 @@ class _PodcastDetailsState extends State<PodcastDetails> {
   @override
   void didChangeDependencies() {
     _systemOverlayStyle = SystemUiOverlayStyle(
-      statusBarIconBrightness: Theme.of(context).brightness == Brightness.light ? Brightness.dark : Brightness.light,
-      statusBarColor: Theme.of(context).appBarTheme.backgroundColor.withOpacity(toolbarCollapsed ? 1.0 : 0.5),
+      statusBarIconBrightness: Theme.of(context).brightness == Brightness.light
+          ? Brightness.dark
+          : Brightness.light,
+      statusBarColor: Theme.of(context)
+          .appBarTheme
+          .backgroundColor
+          .withOpacity(toolbarCollapsed ? 1.0 : 0.5),
     );
     super.didChangeDependencies();
   }
@@ -138,7 +147,7 @@ class _PodcastDetailsState extends State<PodcastDetails> {
             Theme.of(context).brightness == Brightness.light
                 ? Brightness.dark
                 : Brightness.light,
-        systemNavigationBarColor: Theme.of(context).bottomAppBarColor,
+        systemNavigationBarColor: Theme.of(context).bottomAppBarTheme.color,
         statusBarColor: Colors.transparent,
       );
     });
@@ -147,8 +156,14 @@ class _PodcastDetailsState extends State<PodcastDetails> {
   void _updateSystemOverlayStyle() {
     setState(() {
       _systemOverlayStyle = SystemUiOverlayStyle(
-        statusBarIconBrightness: Theme.of(context).brightness == Brightness.light ? Brightness.dark : Brightness.light,
-        statusBarColor: Theme.of(context).appBarTheme.backgroundColor.withOpacity(toolbarCollapsed ? 1.0 : 0.5),
+        statusBarIconBrightness:
+            Theme.of(context).brightness == Brightness.light
+                ? Brightness.dark
+                : Brightness.light,
+        statusBarColor: Theme.of(context)
+            .appBarTheme
+            .backgroundColor
+            .withOpacity(toolbarCollapsed ? 1.0 : 0.5),
       );
     });
   }
@@ -181,11 +196,16 @@ class _PodcastDetailsState extends State<PodcastDetails> {
                         duration: Duration(milliseconds: 500),
                         child: Text(widget.podcast.title)),
                     leading: DecoratedIconButton(
-                      icon: Platform.isAndroid ? Icons.close : Icons.arrow_back_ios,
-                      iconColour: toolbarCollapsed && Theme.of(context).brightness == Brightness.light
+                      icon: Platform.isAndroid
+                          ? Icons.close
+                          : Icons.arrow_back_ios,
+                      iconColour: toolbarCollapsed &&
+                              Theme.of(context).brightness == Brightness.light
                           ? Theme.of(context).appBarTheme.foregroundColor
                           : Colors.white,
-                      decorationColour: toolbarCollapsed ? Color(0x00000000) : Color(0x22000000),
+                      decorationColour: toolbarCollapsed
+                          ? Color(0x00000000)
+                          : Color(0x22000000),
                       onPressed: () {
                         _resetSystemOverlayStyle();
                         Navigator.pop(context);
@@ -197,8 +217,10 @@ class _PodcastDetailsState extends State<PodcastDetails> {
                     snap: false,
                     flexibleSpace: FlexibleSpaceBar(
                       background: Hero(
-                        key: Key('detailhero${widget.podcast.imageUrl}:${widget.podcast.link}'),
-                        tag: '${widget.podcast.imageUrl}:${widget.podcast.link}',
+                        key: Key(
+                            'detailhero${widget.podcast.imageUrl}:${widget.podcast.link}'),
+                        tag:
+                            '${widget.podcast.imageUrl}:${widget.podcast.link}',
                         child: ExcludeSemantics(
                           child: StreamBuilder<BlocState<Podcast>>(
                               initialData: BlocEmptyState<Podcast>(),
@@ -257,7 +279,7 @@ class _PodcastDetailsState extends State<PodcastDetails> {
                                 ),
                                 Text(
                                   L.of(context).no_podcast_details_message,
-                                  style: Theme.of(context).textTheme.bodyText2,
+                                  style: Theme.of(context).textTheme.bodyMedium,
                                   textAlign: TextAlign.center,
                                 ),
                               ],
@@ -269,6 +291,7 @@ class _PodcastDetailsState extends State<PodcastDetails> {
                       if (state is BlocPopulatedState<Podcast>) {
                         return SliverToBoxAdapter(
                             child: PlaybackErrorListener(
+                          margin: 52.0,
                           child: Column(
                             crossAxisAlignment: CrossAxisAlignment.start,
                             children: <Widget>[
@@ -318,7 +341,9 @@ class PodcastHeaderImage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    if (podcast == null || podcast.imageUrl == null || podcast.imageUrl.isEmpty) {
+    if (podcast == null ||
+        podcast.imageUrl == null ||
+        podcast.imageUrl.isEmpty) {
       return Container(
         height: 560,
         width: 560,
@@ -329,11 +354,13 @@ class PodcastHeaderImage extends StatelessWidget {
       key: Key('details${podcast.imageUrl}'),
       url: podcast.imageUrl,
       fit: BoxFit.cover,
-      placeholder:
-          placeholderBuilder != null ? placeholderBuilder?.builder()(context) : DelayedCircularProgressIndicator(),
+      placeholder: placeholderBuilder != null
+          ? placeholderBuilder?.builder()(context)
+          : DelayedCircularProgressIndicator(),
       errorPlaceholder: placeholderBuilder != null
           ? placeholderBuilder?.errorBuilder()(context)
-          : Image(image: AssetImage('assets/images/anytime-placeholder-logo.png')),
+          : Image(
+              image: AssetImage('assets/images/anytime-placeholder-logo.png')),
     );
   }
 }
@@ -357,11 +384,11 @@ class PodcastTitle extends StatelessWidget {
         children: <Widget>[
           Padding(
             padding: const EdgeInsets.symmetric(horizontal: 8),
-            child: Text(podcast.title ?? '', style: textTheme.headline6),
+            child: Text(podcast.title ?? '', style: textTheme.titleLarge),
           ),
           Padding(
             padding: const EdgeInsets.fromLTRB(8, 4, 8, 8),
-            child: Text(podcast.copyright ?? '', style: textTheme.caption),
+            child: Text(podcast.copyright ?? '', style: textTheme.bodySmall),
           ),
           PodcastHtml(content: podcast.description),
           Padding(
@@ -384,7 +411,8 @@ class PodcastTitle extends StatelessWidget {
                   ),
                 ),
                 sharePodcastButtonBuilder != null
-                    ? sharePodcastButtonBuilder?.builder(podcast.title, podcast.url)(context)
+                    ? sharePodcastButtonBuilder?.builder(
+                        podcast.title, podcast.url)(context)
                     : const SizedBox(
                         width: 0.0,
                         height: 0.0,
@@ -419,7 +447,8 @@ class SubscriptionButton extends StatelessWidget {
               return p.subscribed
                   ? OutlinedButton.icon(
                       style: OutlinedButton.styleFrom(
-                        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8.0)),
+                        shape: RoundedRectangleBorder(
+                            borderRadius: BorderRadius.circular(8.0)),
                       ),
                       icon: Icon(
                         Icons.delete_outline,
@@ -461,7 +490,8 @@ class SubscriptionButton extends StatelessWidget {
                     )
                   : OutlinedButton.icon(
                       style: OutlinedButton.styleFrom(
-                        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8.0)),
+                        shape: RoundedRectangleBorder(
+                            borderRadius: BorderRadius.circular(8.0)),
                       ),
                       icon: Icon(
                         Icons.add,
@@ -490,7 +520,8 @@ class SharePodcastButtonBuilder extends InheritedWidget {
         super(key: key, child: child);
 
   static SharePodcastButtonBuilder of(BuildContext context) {
-    return context.dependOnInheritedWidgetOfExactType<SharePodcastButtonBuilder>();
+    return context
+        .dependOnInheritedWidgetOfExactType<SharePodcastButtonBuilder>();
   }
 
   @override

--- a/lib/ui/podcast/podcast_details.dart
+++ b/lib/ui/podcast/podcast_details.dart
@@ -452,6 +452,7 @@ class SubscriptionButton extends StatelessWidget {
                       ),
                       icon: Icon(
                         Icons.delete_outline,
+                        color: Theme.of(context).primaryIconTheme.color,
                       ),
                       label: Text(L.of(context).unsubscribe_label),
                       onPressed: () {
@@ -495,6 +496,7 @@ class SubscriptionButton extends StatelessWidget {
                       ),
                       icon: Icon(
                         Icons.add,
+                        color: Theme.of(context).primaryIconTheme.color,
                       ),
                       label: Text(L.of(context).subscribe_label),
                       onPressed: () {

--- a/lib/ui/podcast/podcast_episode_list.dart
+++ b/lib/ui/podcast/podcast_episode_list.dart
@@ -77,7 +77,7 @@ class PodcastEpisodeList extends StatelessWidget {
               ),
               Text(
                 emptyMessage,
-                style: Theme.of(context).textTheme.headline6,
+                style: Theme.of(context).textTheme.titleLarge,
                 textAlign: TextAlign.center,
               ),
             ],

--- a/lib/ui/podcast/show_notes.dart
+++ b/lib/ui/podcast/show_notes.dart
@@ -45,7 +45,7 @@ class ShowNotes extends StatelessWidget {
                   children: <Widget>[
                     Padding(
                       padding: const EdgeInsets.fromLTRB(16.0, 8.0, 16.0, 8.0),
-                      child: Text(episode.title ?? '', style: textTheme.headline6),
+                      child: Text(episode.title ?? '', style: textTheme.titleLarge),
                     ),
                     Padding(
                       padding: const EdgeInsets.fromLTRB(8.0, 0.0, 8.0, 0.0),

--- a/lib/ui/search/search.dart
+++ b/lib/ui/search/search.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:io';
-
 import 'package:anytime/bloc/search/search_bloc.dart';
 import 'package:anytime/bloc/search/search_state_event.dart';
 import 'package:anytime/l10n/L.dart';
@@ -59,12 +57,16 @@ class _SearchState extends State<Search> {
         slivers: <Widget>[
           SliverAppBar(
             systemOverlayStyle: SystemUiOverlayStyle(
-              statusBarIconBrightness: Theme.of(context).brightness == Brightness.light ? Brightness.dark : Brightness.light,
+              statusBarIconBrightness:
+                  Theme.of(context).brightness == Brightness.light
+                      ? Brightness.dark
+                      : Brightness.light,
               statusBarColor: Colors.transparent,
             ),
             leading: IconButton(
               tooltip: L.of(context).search_back_button_label,
-              icon: Icon(Icons.arrow_back, color: Theme.of(context).appBarTheme.foregroundColor),
+              icon: Icon(Icons.arrow_back,
+                  color: Theme.of(context).appBarTheme.foregroundColor),
               onPressed: () => Navigator.pop(context),
             ),
             title: TextField(

--- a/lib/ui/search/search_results.dart
+++ b/lib/ui/search/search_results.dart
@@ -50,7 +50,7 @@ class SearchResults extends StatelessWidget {
                     ),
                     Text(
                       L.of(context).no_search_results_message,
-                      style: Theme.of(context).textTheme.headline6,
+                      style: Theme.of(context).textTheme.titleLarge,
                       textAlign: TextAlign.center,
                     ),
                   ],

--- a/lib/ui/settings/episode_refresh.dart
+++ b/lib/ui/settings/episode_refresh.dart
@@ -41,7 +41,7 @@ class _EpisodeRefreshWidgetState extends State<EpisodeRefreshWidget> {
                       return AlertDialog(
                           title: Text(
                             L.of(context).settings_auto_update_episodes_heading,
-                            style: Theme.of(context).textTheme.subtitle1,
+                            style: Theme.of(context).textTheme.titleMedium,
                             textAlign: TextAlign.center,
                           ),
                           scrollable: true,

--- a/lib/ui/settings/search_provider.dart
+++ b/lib/ui/settings/search_provider.dart
@@ -42,7 +42,7 @@ class _SearchProviderWidgetState extends State<SearchProviderWidget> {
                           builder: (BuildContext context) {
                             return AlertDialog(
                                 title: Text(L.of(context).search_provider_label,
-                                    style: Theme.of(context).textTheme.subtitle1, textAlign: TextAlign.center),
+                                    style: Theme.of(context).textTheme.titleMedium, textAlign: TextAlign.center),
                                 content: StatefulBuilder(
                                   builder: (BuildContext context, StateSetter setState) {
                                     return Column(mainAxisSize: MainAxisSize.min, children: <Widget>[

--- a/lib/ui/settings/settings.dart
+++ b/lib/ui/settings/settings.dart
@@ -181,7 +181,7 @@ class _SettingsState extends State<Settings> {
   Widget _buildIos(BuildContext context) {
     return CupertinoPageScaffold(
       navigationBar: CupertinoNavigationBar(
-        backgroundColor: Theme.of(context).backgroundColor,
+        backgroundColor: Theme.of(context).colorScheme.background,
       ),
       child: Material(child: _buildList(context)),
     );

--- a/lib/ui/settings/settings_section_label.dart
+++ b/lib/ui/settings/settings_section_label.dart
@@ -20,7 +20,7 @@ class SettingsDividerLabel extends StatelessWidget {
       padding: padding,
       child: Text(
         label,
-        style: Theme.of(context).textTheme.subtitle2.copyWith(
+        style: Theme.of(context).textTheme.titleSmall.copyWith(
               fontSize: 12.0,
               color: Theme.of(context).primaryColor,
             ),

--- a/lib/ui/themes.dart
+++ b/lib/ui/themes.dart
@@ -12,18 +12,15 @@ ThemeData _buildLightTheme() {
   final base = ThemeData.light();
 
   return base.copyWith(
-    colorScheme: ColorScheme.light(
-      primary: Color(0xffff9800),
-      background: Color(0xffffe0b2),
-      onSecondary: Colors.black,
-    ),
     buttonTheme: base.buttonTheme.copyWith(
-        colorScheme: base.buttonTheme.colorScheme
-            .copyWith(onPrimary: Colors.orange, onSecondary: Color(0xffffe0b2), onSurface: Colors.grey[800].withOpacity(0.5))),
+        colorScheme: base.buttonTheme.colorScheme.copyWith(
+            onPrimary: Colors.orange,
+            onSecondary: Color(0xffffe0b2),
+            onSurface: Colors.grey[800].withOpacity(0.5))),
     textButtonTheme: base.textButtonTheme,
     elevatedButtonTheme: base.elevatedButtonTheme,
     outlinedButtonTheme: OutlinedButtonThemeData(
-      style: OutlinedButton.styleFrom(primary: Colors.grey[800]),
+      style: OutlinedButton.styleFrom(foregroundColor: Colors.grey[800]),
     ),
     brightness: Brightness.light,
     primaryColor: Color(0xffff9800),
@@ -31,24 +28,22 @@ ThemeData _buildLightTheme() {
     primaryColorDark: Color(0xfff57c00),
     canvasColor: Color(0xffffffff),
     scaffoldBackgroundColor: Color(0xffffffff),
-    bottomAppBarColor: Color(0xffffffff),
     cardColor: Color(0xffffffff),
     dividerColor: Color(0x1f000000),
     highlightColor: Color(0x66bcbcbc),
     splashColor: Color(0x66c8c8c8),
-    selectedRowColor: Color(0xffff9800),
     unselectedWidgetColor: Color(0x8a000000),
     disabledColor: Color(0x61000000),
-    toggleableActiveColor: Color(0xfffb8c00),
     secondaryHeaderColor: Color(0xfffff3e0),
     textSelectionTheme: TextSelectionThemeData(
-        selectionColor: Color(0xffffcc80), cursorColor: Colors.blue, selectionHandleColor: Color(0xffffb74d)),
-    backgroundColor: Color(0xfffafafa),
+        selectionColor: Color(0xffffcc80),
+        cursorColor: Colors.blue,
+        selectionHandleColor: Color(0xffffb74d)),
     dialogBackgroundColor: Color(0xffffffff),
     indicatorColor: Colors.orange,
     hintColor: Color(0x8a000000),
-    errorColor: Color(0xffd32f2f),
-    primaryTextTheme: Typography.material2018(platform: TargetPlatform.android).black,
+    primaryTextTheme:
+        Typography.material2018(platform: TargetPlatform.android).black,
     textTheme: Typography.material2018(platform: TargetPlatform.android).black,
     primaryIconTheme: IconThemeData(color: Colors.grey[800]),
     iconTheme: base.iconTheme.copyWith(
@@ -73,6 +68,19 @@ ThemeData _buildLightTheme() {
     snackBarTheme: base.snackBarTheme.copyWith(
       actionTextColor: Colors.orange,
     ),
+    bottomAppBarTheme: BottomAppBarTheme(color: Color(0xffffffff)),
+    checkboxTheme: CheckboxThemeData(
+      fillColor:
+          MaterialStateProperty.resolveWith<Color>((Set<MaterialState> states) {
+        if (states.contains(MaterialState.disabled)) {
+          return null;
+        }
+        if (states.contains(MaterialState.selected)) {
+          return Color(0xfffb8c00);
+        }
+        return null;
+      }),
+    ),
     radioTheme: base.radioTheme.copyWith(
       fillColor: MaterialStateProperty.resolveWith(
         (states) {
@@ -83,6 +91,45 @@ ThemeData _buildLightTheme() {
           }
         },
       ),
+    ).copyWith(
+      fillColor:
+          MaterialStateProperty.resolveWith<Color>((Set<MaterialState> states) {
+        if (states.contains(MaterialState.disabled)) {
+          return null;
+        }
+        if (states.contains(MaterialState.selected)) {
+          return Color(0xfffb8c00);
+        }
+        return null;
+      }),
+    ),
+    switchTheme: SwitchThemeData(
+      thumbColor:
+          MaterialStateProperty.resolveWith<Color>((Set<MaterialState> states) {
+        if (states.contains(MaterialState.disabled)) {
+          return null;
+        }
+        if (states.contains(MaterialState.selected)) {
+          return Color(0xfffb8c00);
+        }
+        return null;
+      }),
+      trackColor:
+          MaterialStateProperty.resolveWith<Color>((Set<MaterialState> states) {
+        if (states.contains(MaterialState.disabled)) {
+          return null;
+        }
+        if (states.contains(MaterialState.selected)) {
+          return Color(0xfffb8c00);
+        }
+        return null;
+      }),
+    ),
+    colorScheme: ColorScheme.light(
+      primary: Color(0xffff9800),
+      background: Color(0xfffafafa),
+      onSecondary: Colors.black,
+      error: Color(0xffd32f2f),
     ),
   );
 }
@@ -91,35 +138,28 @@ ThemeData _buildDarktheme() {
   final base = ThemeData.dark();
 
   return base.copyWith(
-    colorScheme: ColorScheme.dark(
-      primary: Color(0xffffffff),
-      background: Color(0x80ffffff),
-      onSecondary: Colors.white,
-    ),
     brightness: Brightness.dark,
     primaryColor: Color(0xffffffff),
     primaryColorLight: Color(0xffffe0b2),
     primaryColorDark: Color(0xfff57c00),
     canvasColor: Color(0xff000000),
     scaffoldBackgroundColor: Color(0xff000000),
-    bottomAppBarColor: Color(0xff222222),
     cardColor: Colors.black,
     dividerColor: Color(0xff444444),
     highlightColor: Color(0xff222222),
     splashColor: Color(0x66c8c8c8),
-    selectedRowColor: Color(0x77ffffff),
     unselectedWidgetColor: Colors.white,
     disabledColor: Color(0x77ffffff),
-    toggleableActiveColor: Color(0xfffb8c00),
     secondaryHeaderColor: Color(0xfffff3e0),
     textSelectionTheme: TextSelectionThemeData(
-        selectionColor: Color(0xffffcc80), cursorColor: Colors.orange, selectionHandleColor: Color(0xffffb74d)),
-    backgroundColor: Color(0xff333333),
+        selectionColor: Color(0xffffcc80),
+        cursorColor: Colors.orange,
+        selectionHandleColor: Color(0xffffb74d)),
     dialogBackgroundColor: Color(0xff222222),
     indicatorColor: Colors.orange,
     hintColor: Color(0x80ffffff),
-    errorColor: Color(0xffd32f2f),
-    primaryTextTheme: Typography.material2018(platform: TargetPlatform.android).white,
+    primaryTextTheme:
+        Typography.material2018(platform: TargetPlatform.android).white,
     textTheme: Typography.material2018(platform: TargetPlatform.android).white,
     primaryIconTheme: IconThemeData(color: Colors.white),
     iconTheme: base.iconTheme.copyWith(
@@ -156,12 +196,24 @@ ThemeData _buildDarktheme() {
     elevatedButtonTheme: base.elevatedButtonTheme,
     outlinedButtonTheme: OutlinedButtonThemeData(
       style: OutlinedButton.styleFrom(
-        primary: Color(0xffffffff),
+        foregroundColor: Color(0xffffffff),
         side: BorderSide(
           color: Color(0xffffffff),
           style: BorderStyle.solid,
         ),
       ),
+    ),
+    checkboxTheme: CheckboxThemeData(
+      fillColor:
+          MaterialStateProperty.resolveWith<Color>((Set<MaterialState> states) {
+        if (states.contains(MaterialState.disabled)) {
+          return null;
+        }
+        if (states.contains(MaterialState.selected)) {
+          return Color(0xfffb8c00);
+        }
+        return null;
+      }),
     ),
     radioTheme: base.radioTheme.copyWith(
       fillColor: MaterialStateProperty.resolveWith(
@@ -169,6 +221,48 @@ ThemeData _buildDarktheme() {
           return Colors.white;
         },
       ),
+    ).copyWith(
+      fillColor:
+          MaterialStateProperty.resolveWith<Color>((Set<MaterialState> states) {
+        if (states.contains(MaterialState.disabled)) {
+          return null;
+        }
+        if (states.contains(MaterialState.selected)) {
+          return Color(0xfffb8c00);
+        }
+        return null;
+      }),
+    ),
+    switchTheme: SwitchThemeData(
+      thumbColor:
+          MaterialStateProperty.resolveWith<Color>((Set<MaterialState> states) {
+        if (states.contains(MaterialState.disabled)) {
+          return null;
+        }
+        if (states.contains(MaterialState.selected)) {
+          return Color(0xfffb8c00);
+        }
+        return null;
+      }),
+      trackColor:
+          MaterialStateProperty.resolveWith<Color>((Set<MaterialState> states) {
+        if (states.contains(MaterialState.disabled)) {
+          return null;
+        }
+        if (states.contains(MaterialState.selected)) {
+          return Color(0xfffb8c00);
+        }
+        return null;
+      }),
+    ),
+    colorScheme: ColorScheme.dark(
+      primary: Color(0xffffffff),
+      background: Color(0xff333333),
+      onSecondary: Colors.white,
+      error: Color(0xffd32f2f),
+    ),
+    bottomAppBarTheme: BottomAppBarTheme(
+      color: Color(0xff222222),
     ),
   );
 }

--- a/lib/ui/widgets/draggable_episode_tile.dart
+++ b/lib/ui/widgets/draggable_episode_tile.dart
@@ -42,7 +42,7 @@ class DraggableEpisodeTile extends StatelessWidget {
         overflow: TextOverflow.ellipsis,
         maxLines: 2,
         softWrap: false,
-        style: textTheme.bodyText2.copyWith(color: theme.iconTheme.color),
+        style: textTheme.bodyMedium.copyWith(color: theme.iconTheme.color),
       ),
       subtitle: EpisodeSubtitle(episode, textColor: theme.iconTheme.color),
       trailing: draggable

--- a/lib/ui/widgets/episode_tile.dart
+++ b/lib/ui/widgets/episode_tile.dart
@@ -86,7 +86,7 @@ class EpisodeTile extends StatelessWidget {
           overflow: TextOverflow.ellipsis,
           maxLines: 2,
           softWrap: false,
-          style: textTheme.bodyText2,
+          style: textTheme.bodyMedium,
         ),
       ),
       children: <Widget>[
@@ -102,7 +102,7 @@ class EpisodeTile extends StatelessWidget {
               overflow: TextOverflow.ellipsis,
               softWrap: false,
               maxLines: 5,
-              style: Theme.of(context).textTheme.bodyText1.copyWith(
+              style: Theme.of(context).textTheme.bodyLarge.copyWith(
                     fontSize: 14,
                     fontWeight: FontWeight.normal,
                   ),
@@ -254,7 +254,7 @@ class EpisodeTile extends StatelessWidget {
                   onPressed: () {
                     showModalBottomSheet<void>(
                         context: context,
-                        backgroundColor: theme.backgroundColor,
+                        backgroundColor: theme.colorScheme.background,
                         isScrollControlled: true,
                         shape: RoundedRectangleBorder(
                           borderRadius: BorderRadius.only(
@@ -385,7 +385,7 @@ class EpisodeSubtitle extends StatelessWidget {
         title,
         overflow: TextOverflow.ellipsis,
         softWrap: false,
-        style: textColor != null ? textTheme.caption.copyWith(color: textColor) : textTheme.caption,
+        style: textColor != null ? textTheme.bodySmall.copyWith(color: textColor) : textTheme.bodySmall,
       ),
     );
   }

--- a/lib/ui/widgets/layout_selector.dart
+++ b/lib/ui/widgets/layout_selector.dart
@@ -62,7 +62,7 @@ class _LayoutSelectorWidgetState extends State<LayoutSelectorWidget> {
                           ),
                           Text(
                             L.of(context).layout_label,
-                            style: theme.textTheme.subtitle1,
+                            style: theme.textTheme.titleMedium,
                           ),
                         ],
                       )),
@@ -76,7 +76,7 @@ class _LayoutSelectorWidgetState extends State<LayoutSelectorWidget> {
                             settingsBloc.layoutMode(0);
                           },
                           style: OutlinedButton.styleFrom(
-                            backgroundColor: mode == 0 ? theme.bottomAppBarColor : null,
+                            backgroundColor: mode == 0 ? theme.bottomAppBarTheme.color : null,
                           ),
                           child: Icon(
                             Icons.list,
@@ -93,7 +93,7 @@ class _LayoutSelectorWidgetState extends State<LayoutSelectorWidget> {
                             settingsBloc.layoutMode(1);
                           },
                           style: OutlinedButton.styleFrom(
-                            backgroundColor: mode == 1 ? theme.bottomAppBarColor : null,
+                            backgroundColor: mode == 1 ? theme.bottomAppBarTheme.color : null,
                           ),
                           child: Icon(
                             Icons.grid_on,
@@ -110,7 +110,7 @@ class _LayoutSelectorWidgetState extends State<LayoutSelectorWidget> {
                             settingsBloc.layoutMode(2);
                           },
                           style: OutlinedButton.styleFrom(
-                            backgroundColor: mode == 2 ? theme.bottomAppBarColor : null,
+                            backgroundColor: mode == 2 ? theme.bottomAppBarTheme.color : null,
                           ),
                           child: Icon(
                             Icons.grid_view,

--- a/lib/ui/widgets/podcast_html.dart
+++ b/lib/ui/widgets/podcast_html.dart
@@ -22,7 +22,7 @@ class PodcastHtml extends StatelessWidget {
       data: content ?? '',
       style: {
         'html': Style(
-          fontWeight: textTheme.bodyText1.fontWeight,
+          fontWeight: textTheme.bodyLarge.fontWeight,
         )
       },
       tagsList: tagList,

--- a/lib/ui/widgets/podcast_list.dart
+++ b/lib/ui/widgets/podcast_list.dart
@@ -86,7 +86,7 @@ class PodcastList extends StatelessWidget {
               ),
               Text(
                 L.of(context).no_search_results_message,
-                style: Theme.of(context).textTheme.headline6,
+                style: Theme.of(context).textTheme.titleLarge,
                 textAlign: TextAlign.center,
               ),
             ],

--- a/lib/ui/widgets/slider_handle.dart
+++ b/lib/ui/widgets/slider_handle.dart
@@ -18,7 +18,7 @@ class SliderHandle extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final ColorTween handleColor = ColorTween(
-      begin: theme.bottomAppBarColor,
+      begin: theme.bottomAppBarTheme.color,
       end: theme.scaffoldBackgroundColor,
     );
 

--- a/lib/ui/widgets/speed_selector.dart
+++ b/lib/ui/widgets/speed_selector.dart
@@ -117,7 +117,7 @@ class _SpeedSliderState extends State<SpeedSlider> {
           padding: const EdgeInsets.only(top: 8.0, bottom: 8.0),
           child: Text(
             L.of(context).audio_settings_playback_speed_label,
-            style: Theme.of(context).textTheme.headline6,
+            style: Theme.of(context).textTheme.titleLarge,
           ),
         ),
         Divider(),
@@ -125,7 +125,7 @@ class _SpeedSliderState extends State<SpeedSlider> {
           padding: const EdgeInsets.only(top: 16.0),
           child: Text(
             '${speed.toString()}x',
-            style: Theme.of(context).textTheme.headline5,
+            style: Theme.of(context).textTheme.headlineSmall,
           ),
         ),
         Row(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,49 +5,49 @@ version: 1.2.1+74-breez
 
 environment:
   sdk: ">=2.10.0 <3.0.0"
-  flutter: 3.0.0
+  flutter: ">=3.7.1"
 
 dependencies:
   auto_size_text: ^3.0.0
-  audio_service: ^0.18.7
-  audio_session: ^0.1.10
-  connectivity_plus: ^2.3.6+1
+  audio_service: ^0.18.9
+  audio_session: ^0.1.13
+  connectivity_plus: ^3.0.2
   cupertino_icons: ^1.0.5
-  device_info_plus: ^4.1.2
-  extended_image: ^6.2.1
-  file_picker: ^5.0.1
+  device_info_plus: ^8.0.0
+  extended_image: ^7.0.0
+  file_picker: ^5.2.5
   flutter_dialogs: ^3.0.0
-  flutter_downloader: ^1.8.1
-  flutter_html: ^3.0.0-alpha.5
-  flutter_html_svg: ^3.0.0-alpha.3
-  flutter_html_table: ^3.0.0-alpha.3
-  flutter_launcher_icons: ^0.10.0
+  flutter_downloader: ^1.10.1+2
+  flutter_html: ^3.0.0-alpha.6
+  flutter_html_svg: ^3.0.0-alpha.4
+  flutter_html_table: ^3.0.0-alpha.4
+  flutter_launcher_icons: ^0.11.0
   flutter_spinkit: ^5.1.0
-  flutter_svg: ^1.1.3
-  html: ^0.15.0
+  flutter_svg: ^1.1.6
+  html: ^0.15.1
   intl: ^0.17.0
-  just_audio: ^0.9.28
-  logging: ^1.0.2
-  meta: ^1.8.0
+  just_audio: ^0.9.31
+  logging: ^1.1.1
+  meta: ^1.9.0
   mp3_info: ^0.2.0
-  path: ^1.8.2
-  path_provider: ^2.0.11
-  path_provider_platform_interface: ^2.0.4
+  path: ^1.8.3
+  path_provider: ^2.0.12
+  path_provider_platform_interface: ^2.0.5
   percent_indicator: 4.2.2
-  permission_handler: ^10.0.0
+  permission_handler: ^10.2.0
   podcast_search:
     git:
       url: https://github.com/breez/podcast_search.git
       ref: 8190101aa49edf0f501cf3688f32a3a87df137c5
-  provider: ^6.0.3
-  rxdart: ^0.27.5
-  scrollable_positioned_list: ^0.3.2
-  sembast: ^3.2.0+1
+  provider: ^6.0.5
+  rxdart: ^0.27.7
+  scrollable_positioned_list: ^0.3.5
+  sembast: ^3.4.0+6
   share_plus: ^6.3.0
-  shared_preferences: ^2.0.15
+  shared_preferences: ^2.0.17
   uni_links: ^0.5.1
-  url_launcher: ^6.1.5
-  xml: ^6.1.0
+  url_launcher: ^6.1.9
+  xml: ^6.2.2
 
   flutter:
     sdk: flutter
@@ -55,16 +55,17 @@ dependencies:
     sdk: flutter
 
 dev_dependencies:
-  mockito: ^5.3.0
+  mockito: ^5.3.2
   pedantic: ^1.11.1
   flutter_lints: ^2.0.1
-  intl_generator: ^0.3.0
+  intl_generator: ^0.4.1
   flutter_test:
     sdk: flutter
 
 dependency_overrides:
-  meta: ^1.8.0
-  path: ^1.8.2
+  intl: ^0.18.0
+  meta: ^1.9.0
+  path: ^1.8.3
 
 flutter_icons:
   image_path_android: "assets/images/anytime-logo.png"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,7 +5,7 @@ version: 1.2.1+74-breez
 
 environment:
   sdk: ">=2.10.0 <3.0.0"
-  flutter: ">=3.7.5"
+  flutter: ">=3.7.7"
 
 dependencies:
   auto_size_text: ^3.0.0
@@ -15,23 +15,23 @@ dependencies:
   cupertino_icons: ^1.0.5
   device_info_plus: ^8.1.0
   extended_image: ^7.0.2
-  file_picker: ^5.2.5
+  file_picker: ^5.2.6
   flutter_dialogs: ^3.0.0
   flutter_downloader: ^1.10.2
   flutter_html: ^3.0.0-alpha.6
   flutter_launcher_icons: ^0.12.0
   flutter_spinkit: ^5.1.0
-  flutter_svg: ^2.0.2
-  html: ^0.15.1
+  flutter_svg: ^2.0.4
+  html: ^0.15.2
   intl: ^0.18.0
-  just_audio: ^0.9.31
+  just_audio: ^0.9.32
   logging: ^1.1.1
   meta: ^1.9.0
   mp3_info: ^0.2.0
   path: ^1.8.3
   path_provider: ^2.0.13
   path_provider_platform_interface: ^2.0.6
-  percent_indicator: 4.2.2
+  percent_indicator: ^4.2.3
   permission_handler: ^10.2.0
   podcast_search:
     git:
@@ -40,7 +40,7 @@ dependencies:
   provider: ^6.0.5
   rxdart: ^0.27.7
   scrollable_positioned_list: ^0.3.5
-  sembast: ^3.4.0+6
+  sembast: ^3.4.3
   share_plus: ^6.3.1
   shared_preferences: ^2.0.18
   uni_links: ^0.5.1

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,7 +5,7 @@ version: 1.2.1+74-breez
 
 environment:
   sdk: ">=2.10.0 <3.0.0"
-  flutter: ">=3.7.1"
+  flutter: ">=3.7.5"
 
 dependencies:
   auto_size_text: ^3.0.0
@@ -14,14 +14,14 @@ dependencies:
   connectivity_plus: ^3.0.3
   cupertino_icons: ^1.0.5
   device_info_plus: ^8.1.0
-  extended_image: ^7.0.1
+  extended_image: ^7.0.2
   file_picker: ^5.2.5
   flutter_dialogs: ^3.0.0
-  flutter_downloader: ^1.10.1+2
+  flutter_downloader: ^1.10.2
   flutter_html: ^3.0.0-alpha.6
-  flutter_launcher_icons: ^0.11.0
+  flutter_launcher_icons: ^0.12.0
   flutter_spinkit: ^5.1.0
-  flutter_svg: ^2.0.0+1
+  flutter_svg: ^2.0.2
   html: ^0.15.1
   intl: ^0.18.0
   just_audio: ^0.9.31
@@ -29,8 +29,8 @@ dependencies:
   meta: ^1.9.0
   mp3_info: ^0.2.0
   path: ^1.8.3
-  path_provider: ^2.0.12
-  path_provider_platform_interface: ^2.0.5
+  path_provider: ^2.0.13
+  path_provider_platform_interface: ^2.0.6
   percent_indicator: 4.2.2
   permission_handler: ^10.2.0
   podcast_search:
@@ -42,9 +42,9 @@ dependencies:
   scrollable_positioned_list: ^0.3.5
   sembast: ^3.4.0+6
   share_plus: ^6.3.1
-  shared_preferences: ^2.0.17
+  shared_preferences: ^2.0.18
   uni_links: ^0.5.1
-  url_launcher: ^6.1.9
+  url_launcher: ^6.1.10
   xml: ^6.2.2
 
   flutter:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,21 +11,19 @@ dependencies:
   auto_size_text: ^3.0.0
   audio_service: ^0.18.9
   audio_session: ^0.1.13
-  connectivity_plus: ^3.0.2
+  connectivity_plus: ^3.0.3
   cupertino_icons: ^1.0.5
-  device_info_plus: ^8.0.0
-  extended_image: ^7.0.0
+  device_info_plus: ^8.1.0
+  extended_image: ^7.0.1
   file_picker: ^5.2.5
   flutter_dialogs: ^3.0.0
   flutter_downloader: ^1.10.1+2
   flutter_html: ^3.0.0-alpha.6
-  flutter_html_svg: ^3.0.0-alpha.4
-  flutter_html_table: ^3.0.0-alpha.4
   flutter_launcher_icons: ^0.11.0
   flutter_spinkit: ^5.1.0
-  flutter_svg: ^1.1.6
+  flutter_svg: ^2.0.0+1
   html: ^0.15.1
-  intl: ^0.17.0
+  intl: ^0.18.0
   just_audio: ^0.9.31
   logging: ^1.1.1
   meta: ^1.9.0
@@ -43,7 +41,7 @@ dependencies:
   rxdart: ^0.27.7
   scrollable_positioned_list: ^0.3.5
   sembast: ^3.4.0+6
-  share_plus: ^6.3.0
+  share_plus: ^6.3.1
   shared_preferences: ^2.0.17
   uni_links: ^0.5.1
   url_launcher: ^6.1.9


### PR DESCRIPTION
Updated Flutter requirements, plugins and all deprecated members.

Tested against App Store build and noticed a regression where Podcast Context & Funding menu icons were invisible on light mode for iOS & Android and on dark mode for Android. This needs confirmation but it looked like there was a regression with Follow/Unfollow icon as well.

### Changelist
- Updated plugins & SDK requirements
  - Share.shareFiles -> Share.shareXFiles [share_plus](https://pub.dev/packages/share_plus/changelog#450)
  - hashValues -> Object.hash [dart:ui>hashValues](https://api.flutter.dev/flutter/dart-ui/hashValues.html)
  - The color and colorBlendMode properties have been removed. Instead, use the colorFilter property. [flutter_svg](https://pub.dev/packages/flutter_svg/changelog#200)
- Updated deprecated theme values 
  - Parallel changes to https://github.com/breez/breezmobile/pull/974
- Fix Podcast Context & Funding menu icon colors 78aacfdf2503177b575833a306c4d1144ebe0877
- Fixed Follow/Unfollow icon color 7c658a92f30a60927809857120458612a91d3686